### PR TITLE
Add graph export API endpoints

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -52,6 +52,7 @@ BrainBank is a hybrid Vector/Graph RAG system. It ingests markdown documents, ex
 ```
 backend/
   api.py                    - FastAPI /ingest and /query endpoints
+  api_graph.py              - FastAPI router: /api/graph, /api/concepts, /api/documents, /api/stats
   db/
     lance.py                - LanceDB init + chunks table schema
     kuzu.py                 - Kuzu init + graph schema (nodes + edges)
@@ -59,13 +60,14 @@ backend/
     embeddings.py           - Sentence-transformer embedding functions
     llm.py                  - Gemini API for concept extraction + answer gen
   ingestion/
-    chunker.py              - Text splitting by paragraphs
+    chunker.py              - Semantic text splitting by topic shift
     processor.py            - Ingest pipeline: chunk -> embed -> extract -> store
   retrieval/
     query.py                - Query pipeline: search -> expand -> answer
 tests/
   conftest.py               - Shared fixtures + mock functions
   test_api.py               - API endpoint tests
+  test_api_graph.py         - Graph export API tests
   db/
     test_lance.py           - LanceDB init tests
     test_kuzu.py            - Kuzu init tests
@@ -84,7 +86,7 @@ Each file has a single responsibility. Tests mirror the source structure.
 Input: text + title
   |
   v
-chunker.chunk_text() -- split by paragraphs, ~500 chars each
+chunker.semantic_chunk_text() -- split by topic shift using sentence similarity
   |
   v
 embeddings.embed_texts() -- sentence-transformers -> 384-dim vectors
@@ -143,6 +145,19 @@ The 1-hop graph expansion is what surfaces "hidden" connections - concepts not i
 ### `POST /query`
 - Body: `{"question": "..."}`
 - Returns: `{"answer": "...", "discovery_concepts": [...]}`
+
+### `GET /api/graph`
+- Returns: `{"nodes": [{"id", "type", "name"}], "edges": [{"source", "target", "type"}]}`
+- Full graph for frontend 3D visualization
+
+### `GET /api/concepts`
+- Returns: `{"concepts": [{"name", "document_count", "related_concepts"}]}`
+
+### `GET /api/documents`
+- Returns: `{"documents": [{"doc_id", "name", "chunk_count", "concepts"}]}`
+
+### `GET /api/stats`
+- Returns: `{"total_documents", "total_chunks", "total_concepts", "total_relationships"}`
 
 ## Configuration
 

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,10 +1,12 @@
 from fastapi import FastAPI
 from pydantic import BaseModel
 
+from backend.api_graph import graph_router
 from backend.ingestion.processor import ingest_markdown
 from backend.retrieval.query import query_brainbank
 
 app = FastAPI(title="BrainBank", version="0.1.0")
+app.include_router(graph_router)
 
 
 class IngestRequest(BaseModel):

--- a/backend/api_graph.py
+++ b/backend/api_graph.py
@@ -1,0 +1,140 @@
+from fastapi import APIRouter
+
+from backend.db.kuzu import init_kuzu
+from backend.db.lance import init_lancedb
+
+graph_router = APIRouter(prefix="/api")
+
+
+@graph_router.get("/graph")
+def get_graph():
+    """Return all nodes and edges for frontend visualization."""
+    _, conn = init_kuzu()
+
+    nodes = []
+    edges = []
+
+    # Concept nodes
+    result = conn.execute("MATCH (c:Concept) RETURN c.name")
+    while result.has_next():
+        name = result.get_next()[0]
+        nodes.append({"id": f"concept:{name}", "type": "Concept", "name": name})
+
+    # Document nodes
+    result = conn.execute("MATCH (d:Document) RETURN d.doc_id, d.name")
+    while result.has_next():
+        row = result.get_next()
+        nodes.append({"id": f"doc:{row[0]}", "type": "Document", "name": row[1]})
+
+    # MENTIONS edges
+    result = conn.execute(
+        "MATCH (d:Document)-[:MENTIONS]->(c:Concept) RETURN d.doc_id, c.name"
+    )
+    while result.has_next():
+        row = result.get_next()
+        edges.append(
+            {"source": f"doc:{row[0]}", "target": f"concept:{row[1]}", "type": "MENTIONS"}
+        )
+
+    # RELATED_TO edges
+    result = conn.execute(
+        "MATCH (a:Concept)-[r:RELATED_TO]->(b:Concept) "
+        "RETURN a.name, b.name, r.relationship"
+    )
+    while result.has_next():
+        row = result.get_next()
+        edges.append(
+            {"source": f"concept:{row[0]}", "target": f"concept:{row[1]}", "type": row[2]}
+        )
+
+    return {"nodes": nodes, "edges": edges}
+
+
+@graph_router.get("/concepts")
+def get_concepts():
+    """Return all concepts with document counts and related concepts."""
+    _, conn = init_kuzu()
+
+    concepts = []
+    result = conn.execute("MATCH (c:Concept) RETURN c.name")
+    while result.has_next():
+        name = result.get_next()[0]
+
+        # Count documents that mention this concept
+        doc_result = conn.execute(
+            "MATCH (d:Document)-[:MENTIONS]->(c:Concept {name: $name}) "
+            "RETURN count(d)",
+            parameters={"name": name},
+        )
+        doc_count = doc_result.get_next()[0]
+
+        # Find related concepts
+        rel_result = conn.execute(
+            "MATCH (c:Concept {name: $name})-[:RELATED_TO]-(other:Concept) "
+            "RETURN other.name",
+            parameters={"name": name},
+        )
+        related = []
+        while rel_result.has_next():
+            related.append(rel_result.get_next()[0])
+
+        concepts.append(
+            {"name": name, "document_count": doc_count, "related_concepts": related}
+        )
+
+    return {"concepts": concepts}
+
+
+@graph_router.get("/documents")
+def get_documents():
+    """Return all documents with chunk counts and linked concepts."""
+    _, conn = init_kuzu()
+    _, table = init_lancedb()
+
+    df = table.to_pandas()
+
+    documents = []
+    result = conn.execute("MATCH (d:Document) RETURN d.doc_id, d.name")
+    while result.has_next():
+        row = result.get_next()
+        doc_id, name = row[0], row[1]
+
+        chunk_count = len(df[df["doc_id"] == doc_id])
+
+        # Find concepts mentioned by this document
+        concept_result = conn.execute(
+            "MATCH (d:Document {doc_id: $doc_id})-[:MENTIONS]->(c:Concept) "
+            "RETURN c.name",
+            parameters={"doc_id": doc_id},
+        )
+        concepts = []
+        while concept_result.has_next():
+            concepts.append(concept_result.get_next()[0])
+
+        documents.append(
+            {"doc_id": doc_id, "name": name, "chunk_count": chunk_count, "concepts": concepts}
+        )
+
+    return {"documents": documents}
+
+
+@graph_router.get("/stats")
+def get_stats():
+    """Return aggregate counts across the knowledge graph."""
+    _, conn = init_kuzu()
+    _, table = init_lancedb()
+
+    df = table.to_pandas()
+
+    doc_result = conn.execute("MATCH (d:Document) RETURN count(d)")
+    concept_result = conn.execute("MATCH (c:Concept) RETURN count(c)")
+    rel_result = conn.execute(
+        "MATCH ()-[r:RELATED_TO]->() RETURN count(r)"
+    )
+
+    return {
+        "total_documents": doc_result.get_next()[0],
+        "total_chunks": len(df),
+        "total_concepts": concept_result.get_next()[0],
+        "total_relationships": rel_result.get_next()[0],
+    }

--- a/backend/ingestion/processor.py
+++ b/backend/ingestion/processor.py
@@ -2,7 +2,7 @@ import uuid
 
 from backend.db.kuzu import init_kuzu
 from backend.db.lance import init_lancedb
-from backend.ingestion.chunker import chunk_text
+from backend.ingestion.chunker import semantic_chunk_text as chunk_text
 from backend.services.embeddings import embed_texts
 from backend.services.llm import extract_concepts
 

--- a/tests/ingestion/test_chunker.py
+++ b/tests/ingestion/test_chunker.py
@@ -1,26 +1,41 @@
-from backend.ingestion.chunker import chunk_text
+from backend.ingestion.chunker import semantic_chunk_text
 
 
-class TestChunkText:
-    def test_single_paragraph(self):
-        text = "This is a single paragraph."
-        chunks = chunk_text(text)
+class TestSemanticChunkText:
+    def test_single_sentence(self):
+        text = "This is a single sentence."
+        chunks = semantic_chunk_text(text)
         assert len(chunks) == 1
         assert chunks[0] == text
 
-    def test_multiple_paragraphs(self):
-        text = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph."
-        chunks = chunk_text(text)
+    def test_multiple_sentences(self):
+        text = "First sentence. Second sentence. Third sentence."
+        chunks = semantic_chunk_text(text)
         assert len(chunks) >= 1
         combined = " ".join(chunks)
-        assert "First paragraph" in combined
-        assert "Third paragraph" in combined
+        assert "First sentence" in combined
+        assert "Third sentence" in combined
 
-    def test_empty_text_returns_original(self):
-        chunks = chunk_text("")
-        assert len(chunks) == 1
+    def test_empty_text_returns_empty(self):
+        chunks = semantic_chunk_text("")
+        assert chunks == []
 
-    def test_respects_chunk_size(self):
-        text = "Word " * 200 + "\n\n" + "Word " * 200
-        chunks = chunk_text(text, chunk_size=500)
+    def test_topic_shift_splits(self):
+        text = (
+            "Calculus deals with derivatives and integrals. "
+            "The fundamental theorem connects them. "
+            "I need to buy groceries today. "
+            "Milk and eggs are on my list."
+        )
+        chunks = semantic_chunk_text(text, similarity_threshold=0.5)
+        assert len(chunks) >= 1
+        combined = " ".join(chunks)
+        assert "Calculus" in combined
+        assert "groceries" in combined
+
+    def test_respects_max_chunk_size(self):
+        text = "Word word word. " * 100
+        chunks = semantic_chunk_text(text, max_chunk_size=200)
         assert len(chunks) >= 2
+        for chunk in chunks:
+            assert len(chunk) <= 200 + 50  # allow some overflow from last sentence

--- a/tests/test_api_graph.py
+++ b/tests/test_api_graph.py
@@ -1,0 +1,137 @@
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+from backend.api import app
+from tests.conftest import (
+    mock_embed_texts,
+    mock_extract_concepts,
+)
+
+client = TestClient(app)
+
+
+def _ingest_sample():
+    """Helper to ingest sample data via the API."""
+    with (
+        patch("backend.ingestion.processor.embed_texts", side_effect=mock_embed_texts),
+        patch(
+            "backend.ingestion.processor.extract_concepts",
+            side_effect=mock_extract_concepts,
+        ),
+    ):
+        client.post(
+            "/ingest",
+            json={
+                "text": "Calculus is about Derivatives and Integrals.",
+                "title": "Math Notes",
+            },
+        )
+
+
+class TestGetGraph:
+    def test_response_structure(self):
+        response = client.get("/api/graph")
+        assert response.status_code == 200
+        data = response.json()
+        assert "nodes" in data
+        assert "edges" in data
+        assert isinstance(data["nodes"], list)
+        assert isinstance(data["edges"], list)
+
+    def test_returns_nodes_after_ingest(self):
+        _ingest_sample()
+        response = client.get("/api/graph")
+        data = response.json()
+        assert len(data["nodes"]) > 0
+        node_types = {n["type"] for n in data["nodes"]}
+        assert "Concept" in node_types
+        assert "Document" in node_types
+
+    def test_returns_edges_after_ingest(self):
+        _ingest_sample()
+        response = client.get("/api/graph")
+        data = response.json()
+        assert len(data["edges"]) > 0
+        edge_types = {e["type"] for e in data["edges"]}
+        assert "MENTIONS" in edge_types
+
+    def test_node_shape(self):
+        _ingest_sample()
+        response = client.get("/api/graph")
+        node = response.json()["nodes"][0]
+        assert "id" in node
+        assert "type" in node
+        assert "name" in node
+
+    def test_edge_shape(self):
+        _ingest_sample()
+        response = client.get("/api/graph")
+        edge = response.json()["edges"][0]
+        assert "source" in edge
+        assert "target" in edge
+        assert "type" in edge
+
+
+class TestGetConcepts:
+    def test_response_structure(self):
+        response = client.get("/api/concepts")
+        assert response.status_code == 200
+        data = response.json()
+        assert "concepts" in data
+        assert isinstance(data["concepts"], list)
+
+    def test_concept_shape_after_ingest(self):
+        _ingest_sample()
+        response = client.get("/api/concepts")
+        data = response.json()
+        assert len(data["concepts"]) > 0
+        concept = data["concepts"][0]
+        assert "name" in concept
+        assert "document_count" in concept
+        assert "related_concepts" in concept
+        assert isinstance(concept["document_count"], int)
+        assert isinstance(concept["related_concepts"], list)
+
+
+class TestGetDocuments:
+    def test_response_structure(self):
+        response = client.get("/api/documents")
+        assert response.status_code == 200
+        data = response.json()
+        assert "documents" in data
+        assert isinstance(data["documents"], list)
+
+    def test_document_shape_after_ingest(self):
+        _ingest_sample()
+        response = client.get("/api/documents")
+        data = response.json()
+        assert len(data["documents"]) > 0
+        doc = data["documents"][0]
+        assert "doc_id" in doc
+        assert "name" in doc
+        assert "chunk_count" in doc
+        assert "concepts" in doc
+        assert isinstance(doc["chunk_count"], int)
+        assert isinstance(doc["concepts"], list)
+
+
+class TestGetStats:
+    def test_response_structure(self):
+        response = client.get("/api/stats")
+        assert response.status_code == 200
+        data = response.json()
+        assert "total_documents" in data
+        assert "total_chunks" in data
+        assert "total_concepts" in data
+        assert "total_relationships" in data
+        assert all(isinstance(v, int) for v in data.values())
+
+    def test_counts_after_ingest(self):
+        _ingest_sample()
+        response = client.get("/api/stats")
+        data = response.json()
+        assert data["total_documents"] >= 1
+        assert data["total_chunks"] >= 1
+        assert data["total_concepts"] >= 1
+        assert data["total_relationships"] >= 1


### PR DESCRIPTION
## Summary
- Add `backend/api_graph.py` with 4 read-only endpoints for graph export: `GET /api/graph`, `/api/concepts`, `/api/documents`, `/api/stats`
- Fix broken chunker import in processor.py after semantic chunker was merged
- Update chunker tests to match `semantic_chunk_text` API

## Closes #4

## Test plan
- [ ] `uv run pytest tests/test_api_graph.py -v` — 11 new tests pass
- [ ] `uv run pytest tests/ -v` — all 37 tests pass
- [ ] Verify `/api/graph` returns nodes + edges in format expected by frontend (Issue #1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)