### PR TITLE
Add Ingest Panel UI for notes and file upload

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -65,7 +65,7 @@ The richer extraction schema now exists in the LLM service. Persistence and API 
 ```
 frontend/
   package.json               - Frontend scripts and dependencies
-  vite.config.ts             - Vite React config + /api proxy
+  vite.config.ts             - Vite React config + /api and /ingest proxy
   index.html                 - Frontend HTML entrypoint
   public/assets/
     human-brain.glb          - Embedded glTF brain wireframe asset
@@ -75,10 +75,11 @@ frontend/
     index.css                - Tailwind import + global theme
     components/
       Graph3D.tsx            - 3D graph scene and interaction behavior
+      IngestPanel.tsx        - Note input + file upload for ingestion
       SearchBar.tsx          - Controlled search input
       NodeTooltip.tsx        - Hover tooltip
     hooks/
-      useGraphData.ts        - GET /api/graph with mock fallback
+      useGraphData.ts        - GET /api/graph with mock fallback + refetch
     lib/
       brainModel.ts          - Brain mesh containment math for node bounds
       graphData.ts           - Graph payload validation + normalization
@@ -143,6 +144,15 @@ Graph3D -- react-force-graph-3d scene
   v
 GLTFLoader -- load human-brain.glb, derive containment bounds, render wireframe shell
 ```
+
+### Ingest Panel
+
+The sidebar includes a collapsible IngestPanel with two modes:
+
+1. **Quick Note** - user types a title + markdown content, clicks "Add to Brain"
+2. **File Upload** - user picks a `.md` or `.txt` file, contents are read client-side
+
+Both modes `POST /ingest` with `{title, text}`. On success the panel shows concept count and triggers `useGraphData.refetch()` to reload the 3D graph with new data. Vite proxies `/ingest` to the backend alongside `/api`.
 
 The frontend constrains force-simulated node positions against the actual loaded brain mesh, not just its bounding box. It builds raycastable mesh geometry, finds an interior anchor point, and clamps out-of-bounds nodes back inward with extra surface inset so the full rendered node spheres stay inside the brain shell. During development, Vite proxies `/api/*` requests to `http://localhost:8000`.
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -19,6 +19,7 @@ vi.mock('./hooks/useGraphData', () => ({
     source: 'mock',
     isLoading: false,
     error: null,
+    refetch: () => {},
   }),
 }));
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { startTransition, useDeferredValue, useState } from 'react';
 
 import { Graph3D } from './components/Graph3D';
+import { IngestPanel } from './components/IngestPanel';
 import { SearchBar } from './components/SearchBar';
 import { NODE_TYPE_COLORS, findMatchingNodeIds } from './lib/graphView';
 import { useGraphData } from './hooks/useGraphData';
@@ -19,7 +20,7 @@ function formatSourceLabel(source: 'api' | 'mock'): string {
 }
 
 export default function App() {
-  const { data, source, isLoading, error } = useGraphData();
+  const { data, source, isLoading, error, refetch } = useGraphData();
   const [query, setQuery] = useState('');
   const deferredQuery = useDeferredValue(query);
   const [hoveredNode, setHoveredNode] = useState<GraphNode | null>(null);
@@ -52,6 +53,8 @@ export default function App() {
             matchCount={matchCount}
             onQueryChange={handleQueryChange}
           />
+
+          <IngestPanel onIngestComplete={refetch} />
 
           <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-4">
             <div className="flex items-center justify-between">

--- a/frontend/src/components/IngestPanel.test.tsx
+++ b/frontend/src/components/IngestPanel.test.tsx
@@ -1,0 +1,132 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { IngestPanel } from './IngestPanel';
+
+const onIngestComplete = vi.fn();
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  onIngestComplete.mockClear();
+});
+
+describe('IngestPanel', () => {
+  it('renders the panel header and toggle', () => {
+    render(<IngestPanel onIngestComplete={onIngestComplete} />);
+    expect(screen.getByText('Add Knowledge')).toBeInTheDocument();
+  });
+
+  it('shows the form when expanded', async () => {
+    const user = userEvent.setup();
+    render(<IngestPanel onIngestComplete={onIngestComplete} />);
+
+    await user.click(screen.getByRole('button', { name: /add knowledge/i }));
+
+    expect(screen.getByPlaceholderText('Note title')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/write your note/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add to brain/i })).toBeInTheDocument();
+  });
+
+  it('submits a quick note and shows success', async () => {
+    const user = userEvent.setup();
+    const mockResponse = { concepts: ['Calculus', 'Derivatives'], doc_id: 'abc' };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    } as Response);
+
+    render(<IngestPanel onIngestComplete={onIngestComplete} />);
+    await user.click(screen.getByRole('button', { name: /add knowledge/i }));
+
+    await user.type(screen.getByPlaceholderText('Note title'), 'My Note');
+    await user.type(screen.getByPlaceholderText(/write your note/i), 'Some content about math');
+    await user.click(screen.getByRole('button', { name: /add to brain/i }));
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/ingest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ title: 'My Note', text: 'Some content about math' }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/2 concepts extracted/i)).toBeInTheDocument();
+    });
+
+    expect(onIngestComplete).toHaveBeenCalled();
+  });
+
+  it('shows error when ingest fails', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: false,
+      status: 500,
+    } as Response);
+
+    render(<IngestPanel onIngestComplete={onIngestComplete} />);
+    await user.click(screen.getByRole('button', { name: /add knowledge/i }));
+
+    await user.type(screen.getByPlaceholderText('Note title'), 'Fail Note');
+    await user.type(screen.getByPlaceholderText(/write your note/i), 'Content');
+    await user.click(screen.getByRole('button', { name: /add to brain/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/ingest failed/i)).toBeInTheDocument();
+    });
+
+    expect(onIngestComplete).not.toHaveBeenCalled();
+  });
+
+  it('disables submit when title or content is empty', async () => {
+    const user = userEvent.setup();
+    render(<IngestPanel onIngestComplete={onIngestComplete} />);
+    await user.click(screen.getByRole('button', { name: /add knowledge/i }));
+
+    const submitBtn = screen.getByRole('button', { name: /add to brain/i });
+    expect(submitBtn).toBeDisabled();
+
+    await user.type(screen.getByPlaceholderText('Note title'), 'Title');
+    expect(submitBtn).toBeDisabled();
+
+    await user.type(screen.getByPlaceholderText(/write your note/i), 'Content');
+    expect(submitBtn).not.toBeDisabled();
+  });
+
+  it('uploads a file and ingests its contents', async () => {
+    const user = userEvent.setup();
+    const mockResponse = { concepts: ['Physics'], doc_id: 'xyz' };
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    } as Response);
+
+    render(<IngestPanel onIngestComplete={onIngestComplete} />);
+    await user.click(screen.getByRole('button', { name: /add knowledge/i }));
+
+    const file = new File(['# Physics Notes\nForce equals mass times acceleration'], 'physics.md', {
+      type: 'text/markdown',
+    });
+
+    const fileInput = screen.getByTestId('file-input');
+    await user.upload(fileInput, file);
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/ingest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: 'physics',
+          text: '# Physics Notes\nForce equals mass times acceleration',
+        }),
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/1 concept extracted/i)).toBeInTheDocument();
+    });
+
+    expect(onIngestComplete).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/IngestPanel.tsx
+++ b/frontend/src/components/IngestPanel.tsx
@@ -1,0 +1,150 @@
+import { useRef, useState } from 'react';
+
+interface IngestPanelProps {
+  onIngestComplete: () => void;
+}
+
+interface IngestResult {
+  type: 'success' | 'error';
+  message: string;
+}
+
+async function postIngest(title: string, text: string): Promise<{ concepts: string[] }> {
+  const response = await fetch('/ingest', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ title, text }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Ingest failed (${response.status})`);
+  }
+
+  return response.json();
+}
+
+export function IngestPanel({ onIngestComplete }: IngestPanelProps) {
+  const [open, setOpen] = useState(false);
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<IngestResult | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  async function handleSubmit() {
+    if (!title.trim() || !content.trim()) return;
+    setSubmitting(true);
+    setResult(null);
+
+    try {
+      const data = await postIngest(title.trim(), content.trim());
+      const count = data.concepts?.length ?? 0;
+      setResult({
+        type: 'success',
+        message: `${count} concept${count === 1 ? '' : 's'} extracted`,
+      });
+      setTitle('');
+      setContent('');
+      onIngestComplete();
+    } catch {
+      setResult({ type: 'error', message: 'Ingest failed' });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const reader = new FileReader();
+    reader.onload = async () => {
+      const text = reader.result as string;
+      const fileName = file.name.replace(/\.[^.]+$/, '');
+
+      setSubmitting(true);
+      setResult(null);
+
+      try {
+        const data = await postIngest(fileName, text);
+        const count = data.concepts?.length ?? 0;
+        setResult({
+          type: 'success',
+          message: `${count} concept${count === 1 ? '' : 's'} extracted`,
+        });
+        onIngestComplete();
+      } catch {
+        setResult({ type: 'error', message: 'Ingest failed' });
+      } finally {
+        setSubmitting(false);
+      }
+    };
+    reader.readAsText(file);
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }
+
+  return (
+    <section className="rounded-3xl border border-white/10 bg-slate-900/60">
+      <button
+        onClick={() => setOpen(!open)}
+        className="flex w-full items-center justify-between p-4 text-sm font-medium text-slate-200"
+      >
+        Add Knowledge
+        <span className="text-xs text-slate-500">{open ? '−' : '+'}</span>
+      </button>
+
+      {open && (
+        <div className="flex flex-col gap-3 border-t border-white/5 p-4">
+          <input
+            type="text"
+            placeholder="Note title"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="rounded-2xl border border-cyan-300/20 bg-slate-950/70 px-4 py-2 text-sm text-slate-100 outline-none transition focus:border-cyan-300/60"
+          />
+          <textarea
+            placeholder="Write your note (markdown supported)"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            rows={4}
+            className="rounded-2xl border border-cyan-300/20 bg-slate-950/70 px-4 py-2 text-sm text-slate-100 outline-none transition focus:border-cyan-300/60"
+          />
+          <button
+            onClick={handleSubmit}
+            disabled={!title.trim() || !content.trim() || submitting}
+            className="rounded-2xl bg-cyan-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-cyan-500 disabled:opacity-40 disabled:hover:bg-cyan-600"
+          >
+            {submitting ? 'Ingesting...' : 'Add to Brain'}
+          </button>
+
+          <div className="flex items-center gap-2">
+            <label className="cursor-pointer rounded-2xl border border-dashed border-slate-600 px-4 py-2 text-center text-xs text-slate-400 transition hover:border-cyan-300/40 hover:text-slate-300">
+              Upload .md / .txt
+              <input
+                ref={fileInputRef}
+                data-testid="file-input"
+                type="file"
+                accept=".md,.txt"
+                onChange={handleFileChange}
+                className="hidden"
+              />
+            </label>
+          </div>
+
+          {result && (
+            <p
+              className={`text-xs ${
+                result.type === 'success' ? 'text-emerald-400' : 'text-red-400'
+              }`}
+            >
+              {result.message}
+            </p>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/frontend/src/hooks/useGraphData.ts
+++ b/frontend/src/hooks/useGraphData.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { normalizeGraphData, validateGraphApiResponse } from '../lib/graphData';
 import { mockGraphApiResponse } from '../mock/mockGraph';
@@ -9,17 +9,23 @@ interface UseGraphDataResult {
   source: GraphSource;
   isLoading: boolean;
   error: string | null;
+  refetch: () => void;
 }
 
 const fallbackGraphData = normalizeGraphData(mockGraphApiResponse);
 
 export function useGraphData(): UseGraphDataResult {
-  const [result, setResult] = useState<UseGraphDataResult>({
+  const [result, setResult] = useState<Omit<UseGraphDataResult, 'refetch'>>({
     data: fallbackGraphData,
     source: 'mock',
     isLoading: true,
     error: null,
   });
+  const [fetchKey, setFetchKey] = useState(0);
+
+  const refetch = useCallback(() => {
+    setFetchKey((k) => k + 1);
+  }, []);
 
   useEffect(() => {
     const controller = new AbortController();
@@ -65,8 +71,8 @@ export function useGraphData(): UseGraphDataResult {
     return () => {
       controller.abort();
     };
-  }, []);
+  }, [fetchKey]);
 
-  return result;
+  return { ...result, refetch };
 }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': 'http://localhost:8000',
+      '/ingest': 'http://localhost:8000',
     },
   },
   test: {


### PR DESCRIPTION
## Summary
- Add collapsible `IngestPanel` component in the sidebar with two ingestion modes: quick note (title + textarea) and file upload (.md/.txt)
- `POST /ingest` on submit, display extracted concept count on success, error message on failure
- Add `refetch()` to `useGraphData` hook so the 3D graph auto-refreshes after ingestion
- Add `/ingest` to Vite proxy config

## Test plan
- [x] 6 new tests for IngestPanel (render, submit, file upload, error, disabled state)
- [x] All 26 frontend tests pass
- [ ] Manual: type a note title + content, click "Add to Brain", verify graph updates
- [ ] Manual: upload a .md file, verify ingestion and graph refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)