### PR TITLE
Add BrainBank 3D graph frontend

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,6 +63,7 @@ The richer extraction schema now exists in the LLM service. Persistence and API 
 ## Project Structure
 
 ```
+run.sh                      - Starts backend and frontend together
 frontend/
   package.json               - Frontend scripts and dependencies
   vite.config.ts             - Vite React config + /api proxy
@@ -80,8 +81,9 @@ frontend/
     hooks/
       useGraphData.ts        - GET /api/graph with mock fallback
     lib/
+      brainModel.ts          - Brain mesh containment math for node bounds
       graphData.ts           - Graph payload validation + normalization
-      graphView.ts           - Colors, adjacency, and match helpers
+      graphView.ts           - Colors, adjacency, search, and camera helpers
     mock/
       mockGraph.ts           - Development graph payload
     test/
@@ -138,12 +140,15 @@ Graph3D -- react-force-graph-3d scene
   |         |
   |         +-- hover -> highlight node + neighbors, tooltip
   |         +-- search -> highlight matches, zoom camera
-  |         +-- idle -> orbit controls auto-rotate
+  |         +-- load -> zoomToFit for default framing
+  |         +-- idle (5s) -> slow camera auto-rotation
+  |         +-- top-right UI buttons -> zoom in / zoom out / reset
+  |         +-- double-click node -> focus camera on that node
   v
-GLTFLoader -- load human-brain.glb as a translucent wireframe shell
+GLTFLoader -- load human-brain.glb, derive mesh containment, render wireframe shell
 ```
 
-The frontend treats the brain model as a visual shell around the graph, not as a hard layout constraint. During development, Vite proxies `/api/*` requests to `http://localhost:8000`.
+The frontend uses the loaded brain mesh as a real containment boundary for the force layout, clamping node positions back inside the model during simulation so nodes do not drift outside the rendered shell. Graph3D also manages its own camera state: it auto-centers on load, resumes slow rotation after 5 seconds of inactivity, cancels rotation on pointer activity, exposes floating controls in the upper-right corner, and supports double-click node focus. During development, Vite proxies `/api/*` requests to `http://localhost:8000`.
 
 ## Ingestion Flow (`POST /ingest`)
 

--- a/frontend/src/components/Graph3D.test.tsx
+++ b/frontend/src/components/Graph3D.test.tsx
@@ -1,8 +1,10 @@
-import { render } from '@testing-library/react';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as THREE from 'three';
 
 import type { GraphData, GraphNode } from '../types/graph';
 import { Graph3D } from './Graph3D';
+import { createBrainContainment, isNodeInsideContainment } from '../lib/brainModel';
 
 const graphPropsSpy = vi.fn();
 const controls = {
@@ -11,10 +13,20 @@ const controls = {
   addEventListener: vi.fn(),
   removeEventListener: vi.fn(),
 };
-const cameraPosition = vi.fn();
+let currentCameraPosition = { x: 200, y: 60, z: 200 };
+const cameraPosition = vi.fn((position?: typeof currentCameraPosition) => {
+  if (!position) {
+    return currentCameraPosition;
+  }
+
+  currentCameraPosition = position;
+  return currentCameraPosition;
+});
 const graph2ScreenCoords = vi.fn(() => ({ x: 160, y: 120 }));
 const sceneAdd = vi.fn();
 const sceneRemove = vi.fn();
+const zoomToFit = vi.fn();
+const refresh = vi.fn();
 
 vi.mock('react-force-graph-3d', async () => {
   const React = await vi.importActual<typeof import('react')>('react');
@@ -25,10 +37,17 @@ vi.mock('react-force-graph-3d', async () => {
         controls: () => controls,
         cameraPosition,
         graph2ScreenCoords,
+        zoomToFit,
         scene: () => ({
           add: sceneAdd,
           remove: sceneRemove,
         }),
+        getGraphBbox: () => ({
+          x: [-100, 100],
+          y: [-60, 60],
+          z: [-80, 80],
+        }),
+        refresh,
       }));
       graphPropsSpy(props);
       return <div data-testid="force-graph" />;
@@ -38,11 +57,11 @@ vi.mock('react-force-graph-3d', async () => {
 
 vi.mock('three/examples/jsm/loaders/GLTFLoader.js', () => ({
   GLTFLoader: class {
-    load(_url: string, onLoad: (value: { scene: { traverse: (fn: (node: object) => void) => void } }) => void) {
+    load(_url: string, onLoad: (value: { scene: THREE.Object3D }) => void) {
+      const scene = new THREE.Group();
+      scene.add(new THREE.Mesh(new THREE.SphereGeometry(50, 8, 8)));
       onLoad({
-        scene: {
-          traverse: () => undefined,
-        },
+        scene,
       });
     }
   },
@@ -78,11 +97,17 @@ const hoveredNode: GraphNode = {
 };
 
 describe('Graph3D', () => {
-  afterEach(() => {
-    vi.clearAllMocks();
+  beforeEach(() => {
+    vi.useFakeTimers();
+    currentCameraPosition = { x: 200, y: 60, z: 200 };
   });
 
-  it('configures orbit auto-rotation and pauses on interaction', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('auto-centers the graph on load', () => {
     render(
       <Graph3D
         data={graph}
@@ -92,10 +117,9 @@ describe('Graph3D', () => {
       />,
     );
 
-    expect(controls.autoRotate).toBe(true);
-    expect(controls.autoRotateSpeed).toBeGreaterThan(0);
-    expect(controls.addEventListener).toHaveBeenCalledWith('start', expect.any(Function));
-    expect(controls.addEventListener).toHaveBeenCalledWith('end', expect.any(Function));
+    vi.advanceTimersByTime(200);
+
+    expect(zoomToFit).toHaveBeenCalledWith(1200, 120);
   });
 
   it('zooms the camera to the first matching search result', () => {
@@ -113,6 +137,29 @@ describe('Graph3D', () => {
       expect.objectContaining({ x: 10, y: 0, z: 0 }),
       1200,
     );
+  });
+
+  it('starts rotating after 5 seconds of idle time and stops on mouse movement', () => {
+    const { container } = render(
+      <Graph3D
+        data={graph}
+        query=""
+        hoveredNode={null}
+        onHoverNode={vi.fn()}
+      />,
+    );
+
+    const callCountBeforeIdle = cameraPosition.mock.calls.length;
+    vi.advanceTimersByTime(5000);
+    vi.advanceTimersByTime(32);
+
+    expect(cameraPosition.mock.calls.length).toBeGreaterThan(callCountBeforeIdle);
+
+    const callCountAfterIdle = cameraPosition.mock.calls.length;
+    fireEvent.mouseMove(container.firstChild as HTMLElement);
+    vi.advanceTimersByTime(100);
+
+    expect(cameraPosition.mock.calls.length).toBe(callCountAfterIdle);
   });
 
   it('highlights connected neighbors while dimming unrelated nodes on hover', () => {
@@ -136,5 +183,82 @@ describe('Graph3D', () => {
       type: 'Project',
       name: 'BrainBank',
     })).toBe('rgba(148, 163, 184, 0.2)');
+  });
+
+  it('renders zoom controls and uses them', () => {
+    const { container } = render(
+      <Graph3D
+        data={graph}
+        query=""
+        hoveredNode={null}
+        onHoverNode={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: '+' }));
+    fireEvent.click(screen.getByRole('button', { name: '−' }));
+    fireEvent.click(screen.getByRole('button', { name: '⟳' }));
+
+    expect(container.querySelector('.absolute.top-4.right-4.flex.flex-col.gap-2')).not.toBeNull();
+    expect(cameraPosition).toHaveBeenCalled();
+    expect(zoomToFit).toHaveBeenCalledWith(1200, 120);
+  });
+
+  it('double-clicking a node focuses it', () => {
+    render(
+      <Graph3D
+        data={graph}
+        query=""
+        hoveredNode={null}
+        onHoverNode={vi.fn()}
+      />,
+    );
+
+    const props = graphPropsSpy.mock.calls.at(-1)?.[0] as {
+      onNodeClick: (node: GraphNode) => void;
+    };
+
+    props.onNodeClick(graph.nodes[1]);
+    vi.advanceTimersByTime(100);
+    props.onNodeClick(graph.nodes[1]);
+
+    expect(cameraPosition).toHaveBeenCalledWith(
+      expect.objectContaining({ x: expect.any(Number), y: expect.any(Number), z: expect.any(Number) }),
+      expect.objectContaining({ x: -10, y: 0, z: 0 }),
+      1200,
+    );
+  });
+
+  it('keeps simulated nodes inside the brain containment volume', () => {
+    render(
+      <Graph3D
+        data={graph}
+        query=""
+        hoveredNode={null}
+        onHoverNode={vi.fn()}
+      />,
+    );
+
+    const props = graphPropsSpy.mock.calls.at(-1)?.[0] as {
+      onEngineTick: () => void;
+    };
+    const outsideNode = graph.nodes[0];
+    outsideNode.x = 250;
+    outsideNode.y = 210;
+    outsideNode.z = 180;
+
+    props.onEngineTick();
+
+    expect(
+      isNodeInsideContainment(
+        outsideNode,
+        createBrainContainment(
+          new THREE.Mesh(
+            new THREE.SphereGeometry(75, 8, 8),
+            new THREE.MeshBasicMaterial(),
+          ),
+        ),
+      ),
+    ).toBe(true);
   });
 });

--- a/frontend/src/components/Graph3D.tsx
+++ b/frontend/src/components/Graph3D.tsx
@@ -5,6 +5,7 @@ import { GLTFLoader } from 'three/examples/jsm/loaders/GLTFLoader.js';
 
 import {
   ACTIVE_LINK_COLOR,
+  autoRotateCamera,
   NODE_TYPE_COLORS,
   buildAdjacencyMap,
   createFocusSet,
@@ -15,7 +16,13 @@ import {
   getConnectionCount,
   getNodeId,
   isDirectHoverLink,
+  zoomToNode,
 } from '../lib/graphView';
+import {
+  clampNodesToContainment,
+  createBrainContainment,
+  type BrainContainment,
+} from '../lib/brainModel';
 import type { GraphData, GraphLink, GraphNode } from '../types/graph';
 import { NodeTooltip } from './NodeTooltip';
 
@@ -28,17 +35,25 @@ interface OrbitControlsLike {
 
 interface ForceGraphHandle {
   controls: () => OrbitControlsLike;
-  cameraPosition: (
+  cameraPosition(): { x: number; y: number; z: number };
+  cameraPosition(
     position: { x: number; y: number; z: number },
-    lookAt: { x: number; y: number; z: number },
-    durationMs: number,
-  ) => void;
+    lookAt?: { x: number; y: number; z: number },
+    durationMs?: number,
+  ): void;
   graph2ScreenCoords: (
     x: number,
     y: number,
     z: number,
   ) => { x: number; y: number };
   scene: () => THREE.Scene;
+  zoomToFit: (durationMs?: number, padding?: number) => void;
+  getGraphBbox: () => {
+    x: [number, number];
+    y: [number, number];
+    z: [number, number];
+  };
+  refresh: () => void;
 }
 
 interface TooltipPosition {
@@ -55,8 +70,13 @@ interface Graph3DProps {
 
 const BRAIN_MODEL_URL = '/assets/human-brain.glb';
 const CAMERA_MOVE_DURATION_MS = 1200;
-const AUTO_ROTATE_SPEED = 0.22;
-const AUTO_ROTATE_RESUME_DELAY_MS = 1200;
+const AUTO_CENTER_PADDING = 120;
+const IDLE_ROTATE_DELAY_MS = 5000;
+const IDLE_ROTATE_INTERVAL_MS = 16;
+const IDLE_ROTATE_SPEED = 0.002;
+const BUTTON_ZOOM_IN_FACTOR = 0.84;
+const BUTTON_ZOOM_OUT_FACTOR = 1.2;
+const DOUBLE_CLICK_THRESHOLD_MS = 300;
 
 export function Graph3D({
   data,
@@ -65,6 +85,13 @@ export function Graph3D({
   onHoverNode,
 }: Graph3DProps) {
   const graphRef = useRef<ForceGraphHandle | null>(null);
+  const brainContainmentRef = useRef<BrainContainment | null>(null);
+  const idleTimeoutRef = useRef<number | null>(null);
+  const idleRotationIntervalRef = useRef<number | null>(null);
+  const lastNodeClickRef = useRef<{ nodeId: string; timestamp: number } | null>(
+    null,
+  );
+  const lookAtTargetRef = useRef({ x: 0, y: 0, z: 0 });
   const [tooltipPosition, setTooltipPosition] = useState<TooltipPosition | null>(
     null,
   );
@@ -72,45 +99,126 @@ export function Graph3D({
   const matchedNodeIds = findMatchingNodeIds(data.nodes, query);
   const focusedNodeIds = createFocusSet(hoveredNode, adjacency);
 
-  useEffect(() => {
-    const controls = graphRef.current?.controls();
+  function clampNodesWithinBrain(refresh = false) {
+    const containment = brainContainmentRef.current;
 
-    if (!controls) {
+    if (!containment) {
       return;
     }
 
-    let timeoutId: number | undefined;
+    const changed = clampNodesToContainment(data.nodes, containment);
 
-    const pauseAutoRotate = () => {
-      if (timeoutId) {
-        window.clearTimeout(timeoutId);
-      }
+    if (changed && refresh) {
+      graphRef.current?.refresh();
+    }
+  }
 
-      controls.autoRotate = false;
+  function getGraphCenter() {
+    const bounds = graphRef.current?.getGraphBbox();
+
+    if (!bounds) {
+      return { x: 0, y: 0, z: 0 };
+    }
+
+    return {
+      x: (bounds.x[0] + bounds.x[1]) / 2,
+      y: (bounds.y[0] + bounds.y[1]) / 2,
+      z: (bounds.z[0] + bounds.z[1]) / 2,
     };
+  }
 
-    const resumeAutoRotate = () => {
-      if (timeoutId) {
-        window.clearTimeout(timeoutId);
-      }
+  function stopIdleRotation() {
+    if (idleRotationIntervalRef.current !== null) {
+      window.clearInterval(idleRotationIntervalRef.current);
+      idleRotationIntervalRef.current = null;
+    }
+  }
 
-      timeoutId = window.setTimeout(() => {
-        controls.autoRotate = true;
-      }, AUTO_ROTATE_RESUME_DELAY_MS);
+  function scheduleIdleRotation() {
+    if (idleTimeoutRef.current !== null) {
+      window.clearTimeout(idleTimeoutRef.current);
+    }
+
+    idleTimeoutRef.current = window.setTimeout(() => {
+      stopIdleRotation();
+      idleRotationIntervalRef.current = window.setInterval(() => {
+        autoRotateCamera(graphRef);
+      }, IDLE_ROTATE_INTERVAL_MS);
+    }, IDLE_ROTATE_DELAY_MS);
+  }
+
+  function handleInteraction() {
+    stopIdleRotation();
+    scheduleIdleRotation();
+  }
+
+  function handleReset() {
+    lookAtTargetRef.current = getGraphCenter();
+    graphRef.current?.zoomToFit(CAMERA_MOVE_DURATION_MS, AUTO_CENTER_PADDING);
+  }
+
+  function handleZoom(scale: number) {
+    const currentPosition = graphRef.current?.cameraPosition();
+
+    if (!currentPosition) {
+      return;
+    }
+
+    const lookAt = lookAtTargetRef.current;
+
+    graphRef.current?.cameraPosition(
+      {
+        x: lookAt.x + (currentPosition.x - lookAt.x) * scale,
+        y: lookAt.y + (currentPosition.y - lookAt.y) * scale,
+        z: lookAt.z + (currentPosition.z - lookAt.z) * scale,
+      },
+      lookAt,
+      400,
+    );
+  }
+
+  function handleZoomIn() {
+    handleZoom(BUTTON_ZOOM_IN_FACTOR);
+  }
+
+  function handleZoomOut() {
+    handleZoom(BUTTON_ZOOM_OUT_FACTOR);
+  }
+
+  function handleNodeClick(node: GraphNode) {
+    const now = Date.now();
+
+    if (
+      lastNodeClickRef.current &&
+      lastNodeClickRef.current.nodeId === node.id &&
+      now - lastNodeClickRef.current.timestamp <= DOUBLE_CLICK_THRESHOLD_MS
+    ) {
+      zoomToNode(graphRef, node);
+      lookAtTargetRef.current = {
+        x: node.x ?? 0,
+        y: node.y ?? 0,
+        z: node.z ?? 0,
+      };
+      lastNodeClickRef.current = null;
+      return;
+    }
+
+    lastNodeClickRef.current = {
+      nodeId: node.id,
+      timestamp: now,
     };
+  }
 
-    controls.autoRotate = true;
-    controls.autoRotateSpeed = AUTO_ROTATE_SPEED;
-    controls.addEventListener('start', pauseAutoRotate);
-    controls.addEventListener('end', resumeAutoRotate);
+  useEffect(() => {
+    scheduleIdleRotation();
 
     return () => {
-      if (timeoutId) {
-        window.clearTimeout(timeoutId);
+      if (idleTimeoutRef.current !== null) {
+        window.clearTimeout(idleTimeoutRef.current);
+        idleTimeoutRef.current = null;
       }
 
-      controls.removeEventListener('start', pauseAutoRotate);
-      controls.removeEventListener('end', resumeAutoRotate);
+      stopIdleRotation();
     };
   }, []);
 
@@ -150,10 +258,14 @@ export function Graph3D({
               wireframe: true,
               transparent: true,
               opacity: 0.12,
+              side: THREE.DoubleSide,
             });
           }
         });
 
+        brainGroup.updateMatrixWorld(true);
+        brainContainmentRef.current = createBrainContainment(brainGroup);
+        clampNodesWithinBrain(true);
         scene.add(brainGroup);
         return;
       }
@@ -163,12 +275,31 @@ export function Graph3D({
 
     return () => {
       cancelled = true;
+      brainContainmentRef.current = null;
 
       if (brainGroup) {
         scene.remove(brainGroup);
       }
     };
   }, []);
+
+  useEffect(() => {
+    clampNodesWithinBrain(true);
+  }, [data.nodes]);
+
+  useEffect(() => {
+    if (!data.nodes.length) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      handleReset();
+    }, 150);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [data.nodes.length]);
 
   useEffect(() => {
     if (!query.trim()) {
@@ -182,22 +313,12 @@ export function Graph3D({
       return;
     }
 
-    const lookAt = {
+    lookAtTargetRef.current = {
       x: firstMatch.x ?? 0,
       y: firstMatch.y ?? 0,
       z: firstMatch.z ?? 0,
     };
-    const cameraPosition = {
-      x: lookAt.x + 140,
-      y: lookAt.y + 30,
-      z: lookAt.z + 120,
-    };
-
-    graphRef.current?.cameraPosition(
-      cameraPosition,
-      lookAt,
-      CAMERA_MOVE_DURATION_MS,
-    );
+    zoomToNode(graphRef, firstMatch, 140);
   }, [data.nodes, query]);
 
   useEffect(() => {
@@ -260,7 +381,13 @@ export function Graph3D({
   }
 
   return (
-    <div className="relative h-full min-h-[26rem] overflow-hidden rounded-[2rem] border border-white/10 bg-slate-950/70 shadow-[0_0_80px_rgba(8,47,73,0.45)]">
+    <div
+      className="relative h-full min-h-[26rem] overflow-hidden rounded-[2rem] border border-white/10 bg-slate-950/70 shadow-[0_0_80px_rgba(8,47,73,0.45)]"
+      onMouseMove={handleInteraction}
+      onMouseDown={handleInteraction}
+      onWheel={handleInteraction}
+      onTouchStart={handleInteraction}
+    >
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(14,165,233,0.18),_transparent_38%),radial-gradient(circle_at_bottom_left,_rgba(168,85,247,0.14),_transparent_35%)]" />
       <ForceGraph3D
         ref={graphRef as never}
@@ -276,10 +403,35 @@ export function Graph3D({
         cooldownTicks={120}
         d3AlphaDecay={0.02}
         d3VelocityDecay={0.15}
+        onEngineTick={() => clampNodesWithinBrain()}
+        onNodeClick={(node) => handleNodeClick(node as GraphNode)}
         onNodeHover={(node) => onHoverNode((node as GraphNode | null) ?? null)}
         enableNodeDrag={false}
         controlType="orbit"
       />
+      <div className="absolute right-4 top-4 flex flex-col gap-2">
+        <button
+          type="button"
+          onClick={handleZoomIn}
+          className="flex h-11 w-11 items-center justify-center rounded-full bg-slate-800/80 text-xl font-semibold text-slate-100 shadow-lg shadow-slate-950/30 transition hover:bg-slate-700/90"
+        >
+          +
+        </button>
+        <button
+          type="button"
+          onClick={handleZoomOut}
+          className="flex h-11 w-11 items-center justify-center rounded-full bg-slate-800/80 text-xl font-semibold text-slate-100 shadow-lg shadow-slate-950/30 transition hover:bg-slate-700/90"
+        >
+          −
+        </button>
+        <button
+          type="button"
+          onClick={handleReset}
+          className="flex h-11 w-11 items-center justify-center rounded-full bg-slate-800/80 text-xl font-semibold text-slate-100 shadow-lg shadow-slate-950/30 transition hover:bg-slate-700/90"
+        >
+          ⟳
+        </button>
+      </div>
       {hoveredNode && tooltipPosition ? (
         <NodeTooltip
           node={hoveredNode}

--- a/frontend/src/lib/brainModel.test.ts
+++ b/frontend/src/lib/brainModel.test.ts
@@ -1,0 +1,74 @@
+import * as THREE from 'three';
+import { describe, expect, it } from 'vitest';
+
+import {
+  clampNodeToContainment,
+  createBrainContainment,
+  isNodeInsideContainment,
+} from './brainModel';
+import type { GraphNode } from '../types/graph';
+
+describe('brainModel helpers', () => {
+  function createBrainMesh() {
+    return new THREE.Mesh(
+      new THREE.CapsuleGeometry(28, 110, 8, 16),
+      new THREE.MeshBasicMaterial(),
+    );
+  }
+
+  it('derives a mesh-backed containment volume from the brain object', () => {
+    const containment = createBrainContainment(createBrainMesh());
+
+    expect(containment.meshes).toHaveLength(1);
+    expect(containment.center.x).toBeCloseTo(0, 1);
+    expect(containment.center.y).toBeCloseTo(0, 1);
+    expect(containment.center.z).toBeCloseTo(0, 1);
+  });
+
+  it('keeps nodes that are already inside the containment unchanged', () => {
+    const node: GraphNode = {
+      id: 'concept:inside',
+      type: 'Concept',
+      name: 'Inside',
+      x: 10,
+      y: 8,
+      z: 6,
+    };
+    const containment = createBrainContainment(createBrainMesh());
+
+    expect(clampNodeToContainment(node, containment)).toBe(false);
+    expect(node).toMatchObject({ x: 10, y: 8, z: 6 });
+    expect(isNodeInsideContainment(node, containment)).toBe(true);
+  });
+
+  it('treats points inside the bounding box but outside the mesh as outside', () => {
+    const containment = createBrainContainment(createBrainMesh());
+
+    expect(
+      isNodeInsideContainment(
+        {
+          x: 24,
+          y: 0,
+          z: 24,
+        },
+        containment,
+      ),
+    ).toBe(false);
+  });
+
+  it('clamps out-of-bounds nodes back inside the containment volume', () => {
+    const node: GraphNode = {
+      id: 'concept:outside',
+      type: 'Concept',
+      name: 'Outside',
+      x: 70,
+      y: 0,
+      z: 55,
+    };
+    const containment = createBrainContainment(createBrainMesh());
+
+    expect(clampNodeToContainment(node, containment)).toBe(true);
+    expect(isNodeInsideContainment(node, containment)).toBe(true);
+  });
+});
+

--- a/frontend/src/lib/brainModel.ts
+++ b/frontend/src/lib/brainModel.ts
@@ -1,0 +1,222 @@
+import * as THREE from 'three';
+
+import type { GraphNode } from '../types/graph';
+
+export interface BrainContainment {
+  center: THREE.Vector3;
+  meshes: THREE.Mesh[];
+}
+
+const VELOCITY_DAMPING = 0.18;
+const INTERSECTION_EPSILON = 1e-3;
+const INSIDE_TEST_DIRECTION = new THREE.Vector3(0.932, 0.271, 0.239).normalize();
+const SURFACE_INSET_DISTANCE = 12;
+const SURFACE_INSET_RATIO = 0.9;
+
+function getNodePoint(node: Pick<GraphNode, 'x' | 'y' | 'z'>): THREE.Vector3 {
+  return new THREE.Vector3(node.x ?? 0, node.y ?? 0, node.z ?? 0);
+}
+
+function createRaycastMesh(sourceMesh: THREE.Mesh): THREE.Mesh {
+  const geometry = sourceMesh.geometry.clone();
+  geometry.applyMatrix4(sourceMesh.matrixWorld);
+
+  return new THREE.Mesh(
+    geometry,
+    new THREE.MeshBasicMaterial({ side: THREE.DoubleSide }),
+  );
+}
+
+function getUniqueIntersectionDistances(
+  meshes: THREE.Mesh[],
+  origin: THREE.Vector3,
+  direction: THREE.Vector3,
+): number[] {
+  const raycaster = new THREE.Raycaster(
+    origin,
+    direction.clone().normalize(),
+    0,
+    Infinity,
+  );
+  const hits = raycaster.intersectObjects(meshes, false);
+  const distances: number[] = [];
+
+  hits.forEach((hit) => {
+    if (hit.distance <= INTERSECTION_EPSILON) {
+      return;
+    }
+
+    const lastDistance = distances.at(-1);
+
+    if (
+      lastDistance === undefined ||
+      Math.abs(hit.distance - lastDistance) > INTERSECTION_EPSILON
+    ) {
+      distances.push(hit.distance);
+    }
+  });
+
+  return distances;
+}
+
+function isPointInsideMeshes(point: THREE.Vector3, meshes: THREE.Mesh[]): boolean {
+  const distances = getUniqueIntersectionDistances(
+    meshes,
+    point,
+    INSIDE_TEST_DIRECTION,
+  );
+
+  return distances.length % 2 === 1;
+}
+
+function findInteriorAnchor(
+  meshes: THREE.Mesh[],
+  bounds: THREE.Box3,
+): THREE.Vector3 {
+  const center = bounds.getCenter(new THREE.Vector3());
+
+  if (isPointInsideMeshes(center, meshes)) {
+    return center;
+  }
+
+  const size = bounds.getSize(new THREE.Vector3());
+  const offsets = [
+    new THREE.Vector3(size.x * 0.1, 0, 0),
+    new THREE.Vector3(-size.x * 0.1, 0, 0),
+    new THREE.Vector3(0, size.y * 0.1, 0),
+    new THREE.Vector3(0, -size.y * 0.1, 0),
+    new THREE.Vector3(0, 0, size.z * 0.1),
+    new THREE.Vector3(0, 0, -size.z * 0.1),
+  ];
+
+  for (const offset of offsets) {
+    const candidate = center.clone().add(offset);
+
+    if (isPointInsideMeshes(candidate, meshes)) {
+      return candidate;
+    }
+  }
+
+  const rayOrigin = new THREE.Vector3(
+    bounds.min.x - size.x,
+    center.y,
+    center.z,
+  );
+  const intersections = getUniqueIntersectionDistances(
+    meshes,
+    rayOrigin,
+    new THREE.Vector3(1, 0, 0),
+  );
+
+  if (intersections.length >= 2) {
+    return rayOrigin.clone().add(
+      new THREE.Vector3(
+        (intersections[0] + intersections[1]) / 2,
+        0,
+        0,
+      ),
+    );
+  }
+
+  return center;
+}
+
+export function createBrainContainment(root: THREE.Object3D): BrainContainment {
+  root.updateMatrixWorld(true);
+
+  const meshes: THREE.Mesh[] = [];
+  const bounds = new THREE.Box3();
+
+  root.traverse((node) => {
+    if (node instanceof THREE.Mesh) {
+      const raycastMesh = createRaycastMesh(node);
+      meshes.push(raycastMesh);
+      bounds.expandByObject(raycastMesh);
+    }
+  });
+
+  return {
+    center: findInteriorAnchor(meshes, bounds),
+    meshes,
+  };
+}
+
+export function isNodeInsideContainment(
+  node: Pick<GraphNode, 'x' | 'y' | 'z'>,
+  containment: BrainContainment,
+): boolean {
+  return isPointInsideMeshes(getNodePoint(node), containment.meshes);
+}
+
+export function clampNodeToContainment(
+  node: GraphNode,
+  containment: BrainContainment,
+): boolean {
+  if (isNodeInsideContainment(node, containment)) {
+    return false;
+  }
+
+  const origin = containment.center.clone();
+  const targetPoint = getNodePoint(node);
+  const direction = targetPoint.sub(origin);
+
+  if (direction.lengthSq() <= INTERSECTION_EPSILON) {
+    direction.copy(INSIDE_TEST_DIRECTION);
+  }
+
+  const intersections = getUniqueIntersectionDistances(
+    containment.meshes,
+    origin,
+    direction,
+  );
+  const surfaceDistance = intersections[0];
+
+  if (surfaceDistance === undefined) {
+    return false;
+  }
+
+  const clampedDistance = Math.max(
+    Math.min(
+      surfaceDistance * SURFACE_INSET_RATIO,
+      surfaceDistance - SURFACE_INSET_DISTANCE,
+    ),
+    0,
+  );
+  const clampedPoint = origin.add(
+    direction.normalize().multiplyScalar(clampedDistance),
+  );
+
+  node.x = clampedPoint.x;
+  node.y = clampedPoint.y;
+  node.z = clampedPoint.z;
+  node.vx = (node.vx ?? 0) * VELOCITY_DAMPING;
+  node.vy = (node.vy ?? 0) * VELOCITY_DAMPING;
+  node.vz = (node.vz ?? 0) * VELOCITY_DAMPING;
+
+  if (node.fx !== undefined) {
+    node.fx = node.x;
+  }
+
+  if (node.fy !== undefined) {
+    node.fy = node.y;
+  }
+
+  if (node.fz !== undefined) {
+    node.fz = node.z;
+  }
+
+  return true;
+}
+
+export function clampNodesToContainment(
+  nodes: GraphNode[],
+  containment: BrainContainment,
+): boolean {
+  let changed = false;
+
+  nodes.forEach((node) => {
+    changed = clampNodeToContainment(node, containment) || changed;
+  });
+
+  return changed;
+}

--- a/frontend/src/lib/graphView.test.ts
+++ b/frontend/src/lib/graphView.test.ts
@@ -1,10 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   NODE_TYPE_COLORS,
+  autoRotateCamera,
   buildAdjacencyMap,
   findMatchingNodeIds,
   getConnectionCount,
+  zoomToNode,
 } from './graphView';
 import type { GraphData } from '../types/graph';
 
@@ -59,5 +61,58 @@ describe('graphView helpers', () => {
     const matches = findMatchingNodeIds(graph.nodes, 'calc');
 
     expect(matches).toEqual(new Set(['concept:Calculus']));
+  });
+
+  it('rotates the camera around the y axis', () => {
+    let currentPosition = { x: 100, y: 25, z: 0 };
+    const cameraPosition = vi.fn((position?: typeof currentPosition) => {
+      if (!position) {
+        return currentPosition;
+      }
+
+      currentPosition = position;
+      return currentPosition;
+    });
+    const fgRef = {
+      current: {
+        cameraPosition,
+      },
+    };
+
+    autoRotateCamera(fgRef, 0.01);
+
+    expect(cameraPosition).toHaveBeenLastCalledWith({
+      x: expect.closeTo(99.995, 3),
+      y: 25,
+      z: expect.closeTo(0.9999, 3),
+    });
+  });
+
+  it('zooms the camera to a node', () => {
+    const cameraPosition = vi.fn();
+    const fgRef = {
+      current: {
+        cameraPosition,
+      },
+    };
+
+    zoomToNode(
+      fgRef,
+      {
+        id: 'concept:Calculus',
+        type: 'Concept',
+        name: 'Calculus',
+        x: 10,
+        y: 5,
+        z: -5,
+      },
+      120,
+    );
+
+    expect(cameraPosition).toHaveBeenCalledWith(
+      { x: 130, y: 35, z: 115 },
+      { x: 10, y: 5, z: -5 },
+      1200,
+    );
   });
 });

--- a/frontend/src/lib/graphView.ts
+++ b/frontend/src/lib/graphView.ts
@@ -1,5 +1,24 @@
 import type { GraphData, GraphLink, GraphNode, GraphNodeType } from '../types/graph';
 
+interface CameraPosition {
+  x: number;
+  y: number;
+  z: number;
+}
+
+interface ForceGraphCameraHandle {
+  cameraPosition(): CameraPosition;
+  cameraPosition(
+    position: CameraPosition,
+    lookAt?: CameraPosition,
+    durationMs?: number,
+  ): unknown;
+}
+
+interface ForceGraphCameraRef {
+  current: ForceGraphCameraHandle | null;
+}
+
 export const NODE_TYPE_COLORS: Record<GraphNodeType, string> = {
   Concept: '#3b82f6',
   Document: '#22c55e',
@@ -87,3 +106,44 @@ export function isDirectHoverLink(
   return source === hoveredNode.id || target === hoveredNode.id;
 }
 
+export function autoRotateCamera(
+  fgRef: ForceGraphCameraRef,
+  speed = 0.002,
+): void {
+  const currentPosition = fgRef.current?.cameraPosition();
+
+  if (!currentPosition) {
+    return;
+  }
+
+  const cosine = Math.cos(speed);
+  const sine = Math.sin(speed);
+
+  fgRef.current?.cameraPosition({
+    x: currentPosition.x * cosine - currentPosition.z * sine,
+    y: currentPosition.y,
+    z: currentPosition.x * sine + currentPosition.z * cosine,
+  });
+}
+
+export function zoomToNode(
+  fgRef: ForceGraphCameraRef,
+  node: GraphNode,
+  distance = 100,
+): void {
+  const lookAt = {
+    x: node.x ?? 0,
+    y: node.y ?? 0,
+    z: node.z ?? 0,
+  };
+
+  fgRef.current?.cameraPosition(
+    {
+      x: lookAt.x + distance,
+      y: lookAt.y + distance * 0.25,
+      z: lookAt.z + distance,
+    },
+    lookAt,
+    1200,
+  );
+}

--- a/frontend/src/types/graph.ts
+++ b/frontend/src/types/graph.ts
@@ -12,6 +12,12 @@ export interface GraphNode {
   x?: number;
   y?: number;
   z?: number;
+  vx?: number;
+  vy?: number;
+  vz?: number;
+  fx?: number;
+  fy?: number;
+  fz?: number;
 }
 
 export interface GraphEdge {
@@ -37,4 +43,3 @@ export interface GraphData {
 }
 
 export type GraphSource = 'api' | 'mock';
-

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# BrainBank - Start both backend and frontend
+
+# Check for GEMINI_API_KEY
+if [ -z "$GEMINI_API_KEY" ]; then
+  echo "Error: GEMINI_API_KEY not set"
+  echo "Run: export GEMINI_API_KEY=your_key_here"
+  exit 1
+fi
+
+# Install deps if needed
+if [ ! -d ".venv" ]; then
+  echo "Setting up Python environment..."
+  uv venv && uv pip install -e ".[dev]"
+fi
+
+if [ ! -d "frontend/node_modules" ]; then
+  echo "Installing frontend dependencies..."
+  cd frontend && npm install && cd ..
+fi
+
+# Start backend in background
+echo "Starting backend on :8000..."
+uv run uvicorn backend.api:app --reload --port 8000 &
+BACKEND_PID=$!
+
+# Start frontend
+echo "Starting frontend on :5173..."
+cd frontend && npm run dev &
+FRONTEND_PID=$!
+
+# Cleanup on exit
+trap "kill $BACKEND_PID $FRONTEND_PID 2>/dev/null" EXIT
+
+echo ""
+echo "BrainBank is running!"
+echo "  Frontend: http://localhost:5173"
+echo "  Backend:  http://localhost:8000"
+echo ""
+echo "Press Ctrl+C to stop."
+
+wait


### PR DESCRIPTION
## Summary
- add the standalone React/Vite frontend for the 3D BrainBank graph UI
- add camera polish for auto-centering, idle rotation, top-right controls, and double-click node focus
- keep graph nodes inside the loaded brain mesh and add a root `run.sh` launcher

## Testing
- cd frontend && npm test
- cd frontend && npm run build