### PR TITLE
Fix backend stability and broken brain rendering

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -1,3 +1,6 @@
+import asyncio
+from functools import partial
+
 from fastapi import FastAPI
 from pydantic import BaseModel
 
@@ -20,14 +23,16 @@ class QueryRequest(BaseModel):
 
 
 @app.post("/ingest")
-def ingest(req: IngestRequest):
-    result = ingest_markdown(req.text, req.title)
+async def ingest(req: IngestRequest):
+    loop = asyncio.get_event_loop()
+    result = await loop.run_in_executor(None, partial(ingest_markdown, req.text, req.title))
     return result
 
 
 @app.post("/query")
-def query(req: QueryRequest):
-    result = query_brainbank(req.question)
+async def query(req: QueryRequest):
+    loop = asyncio.get_event_loop()
+    result = await loop.run_in_executor(None, partial(query_brainbank, req.question))
     return {
         "answer": result["answer"],
         "discovery_concepts": result["discovery_concepts"],
@@ -35,9 +40,11 @@ def query(req: QueryRequest):
 
 
 @app.post("/query/test-llm")
-def query_test_llm(req: QueryRequest):
+async def query_test_llm(req: QueryRequest):
+    loop = asyncio.get_event_loop()
+    answer = await loop.run_in_executor(None, partial(generate_test_answer, req.question))
     return {
-        "answer": generate_test_answer(req.question),
+        "answer": answer,
         "discovery_concepts": [],
         "mode": "llm_test",
     }

--- a/backend/api_graph.py
+++ b/backend/api_graph.py
@@ -9,23 +9,29 @@ graph_router = APIRouter(prefix="/api")
 
 @graph_router.get("/graph")
 def get_graph():
-    """Return Concept nodes and RELATED_TO edges for frontend visualization."""
-    try:
-        nodes = []
-        edges = []
+    """Return all nodes and edges for frontend visualization."""
+    _, conn = init_kuzu()
 
-        result = conn.execute("MATCH (c:Concept) RETURN c.name")
-        while result.has_next():
-            name = result.get_next()[0]
-            nodes.append({"id": f"concept:{name}", "type": "Concept", "name": name})
+    nodes = []
+    edges = []
 
-        result = conn.execute(
-            "MATCH (a:Concept)-[r:RELATED_TO]->(b:Concept) RETURN a.name, b.name, r.reason"
+    # Concept nodes from Kuzu
+    result = conn.execute("MATCH (c:Concept) RETURN c.name")
+    while result.has_next():
+        name = result.get_next()[0]
+        nodes.append({"id": f"concept:{name}", "type": "Concept", "name": name})
+
+    # RELATED_TO edges from Kuzu
+    result = conn.execute(
+        "MATCH (a:Concept)-[r:RELATED_TO]->(b:Concept) RETURN a.name, b.name, r.reason"
+    )
+    while result.has_next():
+        row = result.get_next()
+        edges.append(
+            {"source": f"concept:{row[0]}", "target": f"concept:{row[1]}", "type": row[2]}
         )
 
-        return {"nodes": nodes, "edges": edges}
-    finally:
-        print("Finished get_graph, leaving connection open to avoid write locks")
+    return {"nodes": nodes, "edges": edges}
 
 
 @graph_router.get("/concepts")
@@ -40,7 +46,6 @@ def get_concepts():
     while result.has_next():
         name = result.get_next()[0]
 
-        # Count distinct documents that have chunks tagged with this concept
         if df.empty:
             doc_count = 0
         else:
@@ -49,7 +54,6 @@ def get_concepts():
                 exploded[exploded["concepts"] == name]["doc_id"].nunique()
             )
 
-        # Related concepts from Kuzu
         rel_result = conn.execute(
             "MATCH (c:Concept {name: $name})-[:RELATED_TO]-(other:Concept) "
             "RETURN other.name",
@@ -62,7 +66,7 @@ def get_concepts():
         concepts.append(
             {"name": name, "document_count": doc_count, "related_concepts": related}
         )
-    print("Finished get_concepts, leaving connection open to avoid write locks")
+
     return {"concepts": concepts}
 
 
@@ -114,20 +118,18 @@ def get_concept_documents(concept_name: str):
 @graph_router.get("/stats")
 def get_stats():
     """Return aggregate counts across the knowledge graph."""
-    try:
-        _, table = init_lancedb()
-        df = table.to_pandas()
+    _, conn = init_kuzu()
+    _, table = init_lancedb()
+    df = table.to_pandas()
 
-        concept_result = conn.execute("MATCH (c:Concept) RETURN count(c)")
-        rel_result = conn.execute("MATCH ()-[r:RELATED_TO]->() RETURN count(r)")
+    concept_result = conn.execute("MATCH (c:Concept) RETURN count(c)")
+    rel_result = conn.execute("MATCH ()-[r:RELATED_TO]->() RETURN count(r)")
 
-        total_documents = int(df["doc_id"].nunique()) if not df.empty else 0
+    total_documents = int(df["doc_id"].nunique()) if not df.empty else 0
 
-        return {
-            "total_documents": total_documents,
-            "total_chunks": len(df),
-            "total_concepts": concept_result.get_next()[0],
-            "total_relationships": rel_result.get_next()[0],
-        }
-    finally:
-        print("Finished stats, leaving connection open to avoid write locks")
+    return {
+        "total_documents": total_documents,
+        "total_chunks": len(df),
+        "total_concepts": concept_result.get_next()[0],
+        "total_relationships": rel_result.get_next()[0],
+    }

--- a/backend/services/llm.py
+++ b/backend/services/llm.py
@@ -72,7 +72,7 @@ def extract_concepts(text: str, doc_name: str) -> dict:
         '"relationship": "related_to"}]}'
     )
     response = client.models.generate_content(
-        model="gemini-2.5-flash", contents=prompt
+        model=_get_model_name(), contents=prompt
     )
     return _parse_json_response(response.text)
 
@@ -108,7 +108,7 @@ def extract_knowledge(text: str, doc_name: str) -> dict:
         "}"
     )
     response = client.models.generate_content(
-        model="gemini-2.5-flash", contents=prompt
+        model=_get_model_name(), contents=prompt
     )
     return _parse_json_response(response.text)
 
@@ -123,6 +123,24 @@ def generate_answer(query: str, context: str, concepts: list[str]) -> str:
         "Provide a grounded answer based only on the context provided."
     )
     response = client.models.generate_content(
-        model="gemini-2.5-flash", contents=prompt
+        model=_get_model_name(), contents=prompt
+    )
+    return response.text
+
+
+def generate_test_answer(question: str) -> str:
+    """Return a direct model response without any retrieval context."""
+    prompt = (
+        "You are a test route for BrainBank.\n"
+        "Answer the user's question directly and briefly.\n\n"
+        f"Question: {question}"
+    )
+
+    if _get_test_llm_provider() == "ollama":
+        return _generate_ollama_response(question)
+
+    client = _get_client()
+    response = client.models.generate_content(
+        model=_get_model_name(), contents=prompt
     )
     return response.text

--- a/frontend/src/components/Graph3D.tsx
+++ b/frontend/src/components/Graph3D.tsx
@@ -90,6 +90,10 @@ const DOUBLE_CLICK_THRESHOLD_MS = 300;
 const CONTAINER_SPHERE_RADIUS = 22;
 // Distance from concept center at which doc nodes are pinned
 const DOC_ORBIT_RADIUS = 15;
+// Brain home view camera positioning
+const BRAIN_HOME_VIEW_DISTANCE_MULTIPLIER = 2.8;
+const MIN_BRAIN_HOME_VIEW_DISTANCE = 300;
+const BRAIN_HOME_VIEW_VERTICAL_BIAS = 0.15;
 
 export function Graph3D({
   data,


### PR DESCRIPTION
## Summary
- **Async endpoints**: wrap `/ingest`, `/query`, `/query/test-llm` in `run_in_executor` so blocking CPU work (model inference, Gemini API) doesn't freeze uvicorn's event loop
- **Per-request DB connections**: fix `api_graph.py` which had undefined `conn` variable and broken endpoints after teammate's merge
- **Concepts-only graph**: remove Document nodes and MENTIONS edges from `/api/graph` — only Concept nodes and RELATED_TO edges
- **Restore missing function**: `generate_test_answer` was lost during rebase
- **Fix brain rendering**: add missing `BRAIN_HOME_VIEW_*` constants in Graph3D.tsx

## Test plan
- [x] Backend serves multiple sequential ingests without hanging
- [x] `/api/graph` returns only concept nodes
- [x] Gemini concept extraction working with 2.5-flash
- [ ] Manual: save a note, verify concepts appear on brain
- [ ] Manual: brain mesh renders on page load

🤖 Generated with [Claude Code](https://claude.com/claude-code)