### PR TITLE
Keep graph focus centered in viewport

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -80,7 +80,7 @@ frontend/
       useGraphData.ts        - GET /api/graph with mock fallback + refetch
     lib/
       brainModel.ts          - Brain mesh containment math for node bounds
-      brainScene.ts          - Brain model centering and scene-rotation helpers
+      brainScene.ts          - Brain model centering plus scene-focus and rotation helpers
       chatStorage.ts         - localStorage helpers for persisted chat sessions
       graphData.ts           - Graph payload validation + normalization
       graphView.ts           - Colors, adjacency, search, and camera helpers
@@ -160,11 +160,12 @@ Graph3D -- react-force-graph-3d scene
   |         +-- hover -> highlight node + neighbors, tooltip
   |         +-- click RELATED_TO edge -> fetch /api/relationships/details
   |         +-- selected RELATED_TO edge -> persistent highlight + EdgeDetailPanel
-  |         +-- search -> highlight matches, zoom camera
+  |         +-- search -> highlight matches, center the first match in the viewport
   |         +-- load -> zoomToFit for default framing
   |         +-- idle (5s) -> slow in-place scene rotation around the brain center
   |         +-- top-right UI buttons -> zoom in / zoom out / reset
-  |         +-- double-click node -> focus camera on that node
+  |         +-- click node -> move that node to screen center and expand its documents
+  |         +-- double-click node -> center that node more tightly
   |         +-- right-button drag -> rotate the scene object instead of orbiting the camera
   |         +-- panel resize -> recenter the home view for chat-open/chat-closed layouts
   v
@@ -180,7 +181,7 @@ The sidebar has a "New Note" button and a file upload option:
 
 Both modes trigger `useGraphData.refetch()` to reload the 3D graph. Vite proxies `/ingest` to the backend alongside `/api`.
 
-The desktop layout locks the app to the viewport and gives the left rail, main graph/editor area, and chat column their own internal scroll behavior so a standard browser window does not need to scroll the whole page to reach the chat form or the bottom of the sidebar. The frontend also uses the loaded brain mesh as a real containment boundary for the force layout, not just a visual shell. It builds raycastable mesh geometry, finds an interior anchor point, and clamps out-of-bounds nodes back inward with extra surface inset so the full rendered node spheres stay inside the model during simulation. Before the brain is added to the Three.js scene, `brainScene.centerObject3DAtOrigin()` rescales the loaded GLTF, computes its bounding-box centroid, and offsets the model into a zeroed pivot group at the scene origin. `Graph3D` disables the built-in navigation controls, keeps idle motion and right-button drag on the scene object's own rotation, and reserves left-click for node interactions such as focus and document expansion. A `ResizeObserver` watches the graph panel’s real rendered size, feeds those measured dimensions into `ForceGraph3D`, and recalculates the home view both when the chat column opens or closes and when the graph panel receives its first non-zero layout size on initial page load. That keeps the centered brain shell visually centered in the actual graph viewport instead of centering relative to stale pre-layout or full-window dimensions. During development, Vite proxies `/api/*` and `/ingest` requests to `http://localhost:8000`.
+The desktop layout locks the app to the viewport and gives the left rail, main graph/editor area, and chat column their own internal scroll behavior so a standard browser window does not need to scroll the whole page to reach the chat form or the bottom of the sidebar. The frontend also uses the loaded brain mesh as a real containment boundary for the force layout, not just a visual shell. It builds raycastable mesh geometry, finds an interior anchor point, and clamps out-of-bounds nodes back inward with extra surface inset so the full rendered node spheres stay inside the model during simulation. Before the brain is added to the Three.js scene, `brainScene.centerObject3DAtOrigin()` rescales the loaded GLTF, computes its bounding-box centroid, and offsets the model into a zeroed pivot group at the scene origin. `Graph3D` disables the built-in navigation controls, keeps idle motion and right-button drag on the scene object's own rotation, and reserves left-click for node interactions such as focus and document expansion. The scene now tracks a local focus point: the home view pins the brain centroid at world origin, and clicking or searching for a node shifts the scene position so that local node sits at world origin before any camera move. That keeps the actual rotation pivot centered in the viewport by default and keeps the selected node centered while the scene rotates. A `ResizeObserver` watches the graph panel’s real rendered size, feeds those measured dimensions into `ForceGraph3D`, and recalculates the home view both when the chat column opens or closes and when the graph panel receives its first non-zero layout size on initial page load. That keeps the centered brain shell visually centered in the actual graph viewport instead of centering relative to stale pre-layout or full-window dimensions. During development, Vite proxies `/api/*` and `/ingest` requests to `http://localhost:8000`.
 
 When a user clicks a `RELATED_TO` edge, the frontend keeps that exact edge selected, dims unrelated nodes, fetches `/api/relationships/details?source=...&target=...`, and renders `EdgeDetailPanel` with the stored reason plus shared, source-only, and target-only supporting documents. `MENTIONS` edges remain non-interactive.
 

--- a/frontend/src/components/ChatPanel.test.tsx
+++ b/frontend/src/components/ChatPanel.test.tsx
@@ -53,7 +53,7 @@ describe('ChatPanel', () => {
     render(<ChatPanel />);
 
     expect(screen.getByTestId('chat-panel-shell')).toHaveClass('lg:h-full', 'lg:min-h-0');
-    expect(screen.getByTestId('chat-panel-messages')).toHaveClass('lg:min-h-0', 'overflow-y-auto');
+    expect(screen.getByTestId('chat-panel-messages')).toHaveClass('flex-1', 'overflow-y-auto');
     expect(screen.getByTestId('chat-panel-form')).toHaveClass('shrink-0');
     expect(screen.getByText('What am I building?')).toBeInTheDocument();
     expect(screen.getByText('You are building BrainBank.')).toBeInTheDocument();

--- a/frontend/src/components/ChatPanel.tsx
+++ b/frontend/src/components/ChatPanel.tsx
@@ -80,7 +80,6 @@ export function ChatPanel() {
           <div
             data-testid="chat-panel-messages"
             className="flex-1 space-y-3 overflow-y-auto pr-1 lg:min-h-0"
-            className="flex-1 space-y-3 overflow-y-auto pr-1"
           >
             {messages.length === 0 ? (
               <div className="rounded-2xl border border-dashed border-cyan-300/15 bg-slate-950/60 p-4 text-sm leading-6 text-slate-400">

--- a/frontend/src/components/Graph3D.test.tsx
+++ b/frontend/src/components/Graph3D.test.tsx
@@ -139,12 +139,18 @@ describe('Graph3D', () => {
     currentCameraPosition = { x: 200, y: 60, z: 200 };
     controls.target.set.mockClear();
     controls.update.mockClear();
+    vi.stubGlobal('ResizeObserver', MockResizeObserver);
     vi.stubGlobal(
       'fetch',
       vi.fn().mockImplementation((input: RequestInfo | URL) => {
-        const url = String(input);
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
 
-        if (url.startsWith('/api/relationships/details')) {
+        if (url.includes('/api/relationships/details')) {
           return Promise.resolve({
             ok: true,
             json: async () => relationshipDetails,
@@ -181,12 +187,12 @@ describe('Graph3D', () => {
     expect(cameraPosition).toHaveBeenCalledWith(
       expect.objectContaining({
         x: 0,
-        y: expect.closeTo(51.64, 2),
-        z: 364,
+        y: expect.closeTo(27.04, 2),
+        z: 338,
       }),
       expect.objectContaining({
         x: 0,
-        y: expect.closeTo(22.52, 2),
+        y: 0,
         z: 0,
       }),
       1200,
@@ -200,6 +206,7 @@ describe('Graph3D', () => {
     render(
       <Graph3D
         data={graph}
+        source="api"
         query=""
         hoveredNode={null}
         onHoverNode={vi.fn()}
@@ -224,12 +231,12 @@ describe('Graph3D', () => {
     expect(cameraPosition).toHaveBeenLastCalledWith(
       expect.objectContaining({
         x: 0,
-        y: expect.closeTo(51.64, 2),
-        z: 364,
+        y: expect.closeTo(27.04, 2),
+        z: 338,
       }),
       expect.objectContaining({
         x: 0,
-        y: expect.closeTo(22.52, 2),
+        y: 0,
         z: 0,
       }),
       1200,
@@ -247,9 +254,9 @@ describe('Graph3D', () => {
       />,
     );
 
-    expect(cameraPosition).toHaveBeenCalledWith(
-      expect.objectContaining({ x: expect.any(Number), y: expect.any(Number), z: expect.any(Number) }),
-      expect.objectContaining({ x: 10, y: 0, z: 0 }),
+    expect(cameraPosition).toHaveBeenLastCalledWith(
+      expect.objectContaining({ x: 0, y: expect.closeTo(11.2, 2), z: 140 }),
+      expect.objectContaining({ x: 0, y: 0, z: 0 }),
       1200,
     );
   });
@@ -319,6 +326,7 @@ describe('Graph3D', () => {
     const { container } = render(
       <Graph3D
         data={graph}
+        source="api"
         query=""
         hoveredNode={null}
         onHoverNode={vi.fn()}
@@ -350,6 +358,7 @@ describe('Graph3D', () => {
     render(
       <Graph3D
         data={graph}
+        source="api"
         query=""
         hoveredNode={null}
         onHoverNode={vi.fn()}
@@ -382,12 +391,12 @@ describe('Graph3D', () => {
     expect(cameraPosition).toHaveBeenLastCalledWith(
       expect.objectContaining({
         x: 0,
-        y: expect.closeTo(51.64, 2),
-        z: 364,
+        y: expect.closeTo(27.04, 2),
+        z: 338,
       }),
       expect.objectContaining({
         x: 0,
-        y: expect.closeTo(22.52, 2),
+        y: 0,
         z: 0,
       }),
       1200,
@@ -438,12 +447,12 @@ describe('Graph3D', () => {
     expect(cameraPosition).toHaveBeenLastCalledWith(
       expect.objectContaining({
         x: 0,
-        y: expect.closeTo(51.64, 2),
-        z: 364,
+        y: expect.closeTo(27.04, 2),
+        z: 338,
       }),
       expect.objectContaining({
         x: 0,
-        y: expect.closeTo(22.52, 2),
+        y: 0,
         z: 0,
       }),
       1200,
@@ -483,21 +492,118 @@ describe('Graph3D', () => {
       onNodeClick: (node: GraphNode) => void;
     };
 
-    props.onNodeClick(graph.nodes[1]);
-    vi.advanceTimersByTime(100);
-    props.onNodeClick(graph.nodes[1]);
+    act(() => {
+      props.onNodeClick(graph.nodes[1]);
+      vi.advanceTimersByTime(100);
+      props.onNodeClick(graph.nodes[1]);
+    });
 
-    expect(cameraPosition).toHaveBeenCalledWith(
-      expect.objectContaining({ x: expect.any(Number), y: expect.any(Number), z: expect.any(Number) }),
-      expect.objectContaining({ x: -10, y: 0, z: 0 }),
+    expect(cameraPosition).toHaveBeenLastCalledWith(
+      expect.objectContaining({ x: 0, y: 8, z: 100 }),
+      expect.objectContaining({ x: 0, y: 0, z: 0 }),
       1200,
     );
+  });
+
+  it('clicking a node centers that node at the screen pivot', async () => {
+    render(
+      <Graph3D
+        data={graph}
+        source="api"
+        query=""
+        hoveredNode={null}
+        onHoverNode={vi.fn()}
+      />,
+    );
+
+    vi.advanceTimersByTime(200);
+    cameraPosition.mockClear();
+
+    await act(async () => {
+      (graphPropsSpy.mock.calls.at(-1)?.[0] as {
+        onNodeClick: (n: GraphNode) => void;
+      }).onNodeClick(graph.nodes[1]);
+    });
+
+    const centeredPoint = sceneObject.localToWorld(
+      new THREE.Vector3(
+        graph.nodes[1].x ?? 0,
+        graph.nodes[1].y ?? 0,
+        graph.nodes[1].z ?? 0,
+      ),
+    );
+
+    expect(centeredPoint.x).toBeCloseTo(0, 4);
+    expect(centeredPoint.y).toBeCloseTo(0, 4);
+    expect(centeredPoint.z).toBeCloseTo(0, 4);
+    expect(cameraPosition).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        x: 0,
+        y: expect.any(Number),
+        z: expect.any(Number),
+      }),
+      expect.objectContaining({ x: 0, y: 0, z: 0 }),
+      1200,
+    );
+  });
+
+  it('keeps the clicked node centered while rotating the scene', async () => {
+    const { container } = render(
+      <Graph3D
+        data={graph}
+        source="api"
+        query=""
+        hoveredNode={null}
+        onHoverNode={vi.fn()}
+      />,
+    );
+
+    vi.advanceTimersByTime(200);
+
+    await act(async () => {
+      (graphPropsSpy.mock.calls.at(-1)?.[0] as {
+        onNodeClick: (n: GraphNode) => void;
+      }).onNodeClick(graph.nodes[0]);
+    });
+
+    const root = container.firstChild as HTMLElement;
+
+    fireEvent.mouseDown(root, {
+      button: 2,
+      buttons: 2,
+      clientX: 100,
+      clientY: 120,
+    });
+    fireEvent.mouseMove(root, {
+      buttons: 2,
+      clientX: 140,
+      clientY: 90,
+    });
+    fireEvent.mouseUp(root, { button: 2 });
+
+    const centeredPoint = sceneObject.localToWorld(
+      new THREE.Vector3(
+        graph.nodes[0].x ?? 0,
+        graph.nodes[0].y ?? 0,
+        graph.nodes[0].z ?? 0,
+      ),
+    );
+
+    expect(centeredPoint.x).toBeCloseTo(0, 4);
+    expect(centeredPoint.y).toBeCloseTo(0, 4);
+    expect(centeredPoint.z).toBeCloseTo(0, 4);
   });
 
   describe('Concept node document expansion', () => {
     it('clicking a Document node is a no-op and does not fetch', async () => {
       render(
-        <Graph3D data={graph} query="" hoveredNode={null} onHoverNode={vi.fn()} />,
+        <Graph3D
+          data={graph}
+          source="api"
+          query=""
+          hoveredNode={null}
+          onHoverNode={vi.fn()}
+        />,
       );
       const { onNodeClick } = graphPropsSpy.mock.calls.at(-1)?.[0] as {
         onNodeClick: (n: GraphNode) => void;
@@ -512,7 +618,13 @@ describe('Graph3D', () => {
 
     it('clicking a Concept node fetches its documents from the API', async () => {
       render(
-        <Graph3D data={graph} query="" hoveredNode={null} onHoverNode={vi.fn()} />,
+        <Graph3D
+          data={graph}
+          source="api"
+          query=""
+          hoveredNode={null}
+          onHoverNode={vi.fn()}
+        />,
       );
       const { onNodeClick } = graphPropsSpy.mock.calls.at(-1)?.[0] as {
         onNodeClick: (n: GraphNode) => void;
@@ -537,7 +649,13 @@ describe('Graph3D', () => {
       });
 
       render(
-        <Graph3D data={graph} query="" hoveredNode={null} onHoverNode={vi.fn()} />,
+        <Graph3D
+          data={graph}
+          source="api"
+          query=""
+          hoveredNode={null}
+          onHoverNode={vi.fn()}
+        />,
       );
       const { onNodeClick } = graphPropsSpy.mock.calls.at(-1)?.[0] as {
         onNodeClick: (n: GraphNode) => void;
@@ -567,7 +685,13 @@ describe('Graph3D', () => {
       });
 
       render(
-        <Graph3D data={graph} query="" hoveredNode={null} onHoverNode={vi.fn()} />,
+        <Graph3D
+          data={graph}
+          source="api"
+          query=""
+          hoveredNode={null}
+          onHoverNode={vi.fn()}
+        />,
       );
 
       // First click — expand
@@ -606,7 +730,13 @@ describe('Graph3D', () => {
       );
 
       render(
-        <Graph3D data={graph} query="" hoveredNode={null} onHoverNode={vi.fn()} />,
+        <Graph3D
+          data={graph}
+          source="api"
+          query=""
+          hoveredNode={null}
+          onHoverNode={vi.fn()}
+        />,
       );
 
       // Click Calculus

--- a/frontend/src/components/Graph3D.tsx
+++ b/frontend/src/components/Graph3D.tsx
@@ -23,6 +23,7 @@ import {
 } from '../lib/brainModel';
 import {
   centerObject3DAtOrigin,
+  keepLocalPointAtWorldOrigin,
   rotateObjectFromPointerDelta,
 } from '../lib/brainScene';
 import {
@@ -37,7 +38,6 @@ import type {
   RelationshipDetails,
 } from '../types/graph';
 import { EdgeDetailPanel } from './EdgeDetailPanel';
-import { getMockDocumentsForConcept } from '../mock/mockGraph';
 import { NodeTooltip } from './NodeTooltip';
 
 interface OrbitControlsLike {
@@ -81,7 +81,7 @@ interface TooltipPosition {
 
 interface BrainHomeView {
   distance: number;
-  target: {
+  focusPoint: {
     x: number;
     y: number;
     z: number;
@@ -110,14 +110,13 @@ const IDLE_ROTATE_INTERVAL_MS = 16;
 const BUTTON_ZOOM_IN_FACTOR = 0.84;
 const BUTTON_ZOOM_OUT_FACTOR = 1.2;
 const DOUBLE_CLICK_THRESHOLD_MS = 300;
+const BRAIN_HOME_VIEW_DISTANCE_MULTIPLIER = 2.6;
+const MIN_BRAIN_HOME_VIEW_DISTANCE = 240;
 const POINTER_ROTATION_SPEED = 0.005;
 const IDLE_ROTATION_SPEED = 0.002;
 const MAX_SCENE_TILT = Math.PI / 3;
 const CONTAINER_SPHERE_RADIUS = 22;
 const DOC_ORBIT_RADIUS = 15;
-const BRAIN_HOME_VIEW_DISTANCE_MULTIPLIER = 2.8;
-const MIN_BRAIN_HOME_VIEW_DISTANCE = 300;
-const BRAIN_HOME_VIEW_VERTICAL_BIAS = 0.15;
 
 export function Graph3D({
   data,
@@ -134,6 +133,7 @@ export function Graph3D({
   const idleRotationIntervalRef = useRef<number | null>(null);
   const lastNodeClickRef = useRef<{ nodeId: string; timestamp: number } | null>(null);
   const lookAtTargetRef = useRef({ x: 0, y: 0, z: 0 });
+  const sceneFocusPointRef = useRef({ x: 0, y: 0, z: 0 });
   const isRightDragRotatingRef = useRef(false);
   const lastDragPositionRef = useRef({ x: 0, y: 0 });
   const containerSizeRef = useRef({ width: 0, height: 0 });
@@ -261,7 +261,7 @@ export function Graph3D({
     return graphRef.current?.scene() ?? null;
   }
 
-  function resetSceneRotation() {
+  function resetSceneTransform() {
     const rotationRoot = getRotationRoot();
 
     if (!rotationRoot) {
@@ -269,6 +269,7 @@ export function Graph3D({
     }
 
     rotationRoot.rotation.set(0, 0, 0);
+    rotationRoot.position.set(0, 0, 0);
     rotationRoot.updateMatrixWorld(true);
   }
 
@@ -284,21 +285,25 @@ export function Graph3D({
     return rotationRoot.localToWorld(worldPoint);
   }
 
-  function focusPoint(point: { x: number; y: number; z: number }, distance: number) {
-    const worldPoint = toWorldPoint(point);
+  function applySceneFocusPoint() {
+    const rotationRoot = getRotationRoot();
 
-    lookAtTargetRef.current = {
-      x: worldPoint.x,
-      y: worldPoint.y,
-      z: worldPoint.z,
-    };
-    graphRef.current?.cameraPosition(
-      {
-        x: worldPoint.x + distance,
-        y: worldPoint.y + distance * 0.25,
-        z: worldPoint.z + distance,
-      },
+    if (!rotationRoot) {
+      return;
+    }
+
+    keepLocalPointAtWorldOrigin(rotationRoot, sceneFocusPointRef.current);
+    rotationRoot.updateMatrixWorld(true);
+    lookAtTargetRef.current = { x: 0, y: 0, z: 0 };
+  }
+
+  function focusPoint(point: { x: number; y: number; z: number }, distance: number) {
+    sceneFocusPointRef.current = point;
+    applySceneFocusPoint();
+    centerCameraOnTarget(
+      graphRef,
       lookAtTargetRef.current,
+      distance,
       CAMERA_MOVE_DURATION_MS,
     );
   }
@@ -326,7 +331,7 @@ export function Graph3D({
 
         rotationRoot.rotation.order = 'YXZ';
         rotationRoot.rotation.y += IDLE_ROTATION_SPEED;
-        rotationRoot.updateMatrixWorld(true);
+        applySceneFocusPoint();
       }, IDLE_ROTATE_INTERVAL_MS);
     }, IDLE_ROTATE_DELAY_MS);
   }
@@ -340,17 +345,20 @@ export function Graph3D({
     const brainHomeView = brainHomeViewRef.current;
 
     if (brainHomeView) {
-      resetSceneRotation();
-      lookAtTargetRef.current = brainHomeView.target;
+      resetSceneTransform();
+      sceneFocusPointRef.current = brainHomeView.focusPoint;
+      applySceneFocusPoint();
       centerCameraOnTarget(
         graphRef,
-        brainHomeView.target,
+        lookAtTargetRef.current,
         brainHomeView.distance,
         CAMERA_MOVE_DURATION_MS,
       );
       return;
     }
 
+    resetSceneTransform();
+    sceneFocusPointRef.current = { x: 0, y: 0, z: 0 };
     lookAtTargetRef.current = getGraphCenter();
     graphRef.current?.zoomToFit(CAMERA_MOVE_DURATION_MS, AUTO_CENTER_PADDING);
   }
@@ -405,7 +413,7 @@ export function Graph3D({
       POINTER_ROTATION_SPEED,
       MAX_SCENE_TILT,
     );
-    rotationRoot.updateMatrixWorld(true);
+    applySceneFocusPoint();
   }
 
   function handleMouseEnd() {
@@ -654,16 +662,15 @@ export function Graph3D({
         }
       });
 
-      const framedSize = centeredBrain.bounds.getSize(new THREE.Vector3());
       brainContainmentRef.current = createBrainContainment(brainGroup);
       brainHomeViewRef.current = {
         distance: Math.max(
           centeredBrain.sphere.radius * BRAIN_HOME_VIEW_DISTANCE_MULTIPLIER,
           MIN_BRAIN_HOME_VIEW_DISTANCE,
         ),
-        target: {
+        focusPoint: {
           x: centeredBrain.orbitTarget.x,
-          y: centeredBrain.orbitTarget.y + framedSize.y * BRAIN_HOME_VIEW_VERTICAL_BIAS,
+          y: centeredBrain.orbitTarget.y,
           z: centeredBrain.orbitTarget.z,
         },
       };
@@ -854,7 +861,6 @@ export function Graph3D({
           clearSelectedEdge();
         }
       }}
-      onContextMenu={(event) => event.preventDefault()}
       onMouseMove={handleMouseMove}
       onMouseDown={handleMouseDown}
       onMouseUp={handleMouseEnd}

--- a/frontend/src/lib/brainScene.test.ts
+++ b/frontend/src/lib/brainScene.test.ts
@@ -1,7 +1,11 @@
 import * as THREE from 'three';
 import { describe, expect, it } from 'vitest';
 
-import { centerObject3DAtOrigin, rotateObjectFromPointerDelta } from './brainScene';
+import {
+  centerObject3DAtOrigin,
+  keepLocalPointAtWorldOrigin,
+  rotateObjectFromPointerDelta,
+} from './brainScene';
 
 describe('brainScene helpers', () => {
   it('centers a model around the origin and resets the pivot position', () => {
@@ -37,5 +41,23 @@ describe('brainScene helpers', () => {
     expect(target.rotation.x).toBeCloseTo(-0.1, 4);
     expect(target.rotation.y).toBeCloseTo(0.2, 4);
     expect(target.rotation.z).toBe(0);
+  });
+
+  it('repositions a rotated object so a local focus point stays at world origin', () => {
+    const target = new THREE.Group();
+    const focusPoint = new THREE.Vector3(12, 0, -4);
+
+    target.rotation.y = Math.PI / 3;
+    target.rotation.x = -Math.PI / 8;
+    target.updateMatrixWorld(true);
+
+    keepLocalPointAtWorldOrigin(target, focusPoint);
+    target.updateMatrixWorld(true);
+
+    const centeredPoint = target.localToWorld(focusPoint.clone());
+
+    expect(centeredPoint.x).toBeCloseTo(0, 4);
+    expect(centeredPoint.y).toBeCloseTo(0, 4);
+    expect(centeredPoint.z).toBeCloseTo(0, 4);
   });
 });

--- a/frontend/src/lib/brainScene.ts
+++ b/frontend/src/lib/brainScene.ts
@@ -7,6 +7,12 @@ export interface CenteredObject3D {
   orbitTarget: THREE.Vector3;
 }
 
+interface Point3D {
+  x: number;
+  y: number;
+  z: number;
+}
+
 export function centerObject3DAtOrigin(
   model: THREE.Object3D,
   targetDiagonal = 260,
@@ -57,4 +63,15 @@ export function rotateObjectFromPointerDelta(
     -maxTilt,
     maxTilt,
   );
+}
+
+export function keepLocalPointAtWorldOrigin(
+  target: THREE.Object3D,
+  point: Point3D,
+): void {
+  const rotatedPoint = new THREE.Vector3(point.x, point.y, point.z).applyQuaternion(
+    target.quaternion,
+  );
+
+  target.position.copy(rotatedPoint.multiplyScalar(-1));
 }

--- a/frontend/src/mock/mockGraph.ts
+++ b/frontend/src/mock/mockGraph.ts
@@ -126,7 +126,6 @@ const MOCK_CONCEPT_DOCUMENTS: Record<string, MockDocument[]> = {
       doc_id: 'py-1',
       name: 'Python for ML.md',
       full_text:
-        'Python dominates ML tooling through libraries like NumPy, PyTorch, and Hugging Face.',
         'Python dominates the ML ecosystem via NumPy, PyTorch, and the Hugging Face library. Its dynamic typing and REPL workflow suit rapid experimentation.',
     },
   ],


### PR DESCRIPTION
## Summary
- merge the latest `main` into `codex/center-brain-panel`
- keep the brain's rotation pivot centered in the viewport by tracking a local scene focus point
- move clicked and searched nodes into the screen center while preserving right-drag rotation and left-click interaction

## Verification
- cd frontend && npm test -- --run
- cd frontend && npm run build