### PR TITLE
Remove node legend and hover details from sidebar

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -63,7 +63,7 @@ frontend/
     human-brain.glb          - Embedded glTF brain wireframe asset
   src/
     main.tsx                 - React entrypoint
-    App.tsx                  - Layout shell, view switching (graph/editor), legend, search
+    App.tsx                  - Layout shell, view switching (graph/editor), search
     index.css                - Tailwind import + global theme
     components/
       ChatPanel.tsx          - Right-side chat UI with session list and active conversation

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -50,7 +50,7 @@ vi.mock('./components/ChatPanel', () => ({
 import App from './App';
 
 describe('App', () => {
-  it('renders the shell, graph summary, node legend, and keeps chat state when users toggle the panel', async () => {
+  it('renders the shell and graph summary without node legend or hover details', async () => {
     const user = userEvent.setup();
 
     render(<App />);
@@ -72,8 +72,13 @@ describe('App', () => {
     expect(screen.getByRole('button', { name: 'Close chat panel' })).toBeInTheDocument();
     expect(screen.getByText('BrainBank')).toBeInTheDocument();
     expect(screen.getByText('Mock data')).toBeInTheDocument();
-    expect(screen.getByText('Concept')).toBeInTheDocument();
-    expect(screen.getByText('Document')).toBeInTheDocument();
+
+    // Node legend and hover details should NOT be present
+    expect(screen.queryByText('Node legend')).not.toBeInTheDocument();
+    expect(screen.queryByText('Hover details')).not.toBeInTheDocument();
+    expect(screen.queryByText('Hover a node to inspect its local neighborhood.')).not.toBeInTheDocument();
+
+    // Chat toggle still works and preserves state
     await user.type(screen.getByLabelText('Draft'), 'Persist me');
     expect(screen.getByDisplayValue('Persist me')).toBeInTheDocument();
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,16 +20,7 @@ class EditorErrorBoundary extends Component<{ children: ReactNode; onError: () =
   }
 }
 import { useGraphData } from './hooks/useGraphData';
-import { NODE_TYPE_COLORS, findMatchingNodeIds } from './lib/graphView';
-import type { GraphNode, GraphNodeType } from './types/graph';
-
-const NODE_TYPES: GraphNodeType[] = [
-  'Concept',
-  'Document',
-  'Project',
-  'Task',
-  'Reflection',
-];
+import { findMatchingNodeIds } from './lib/graphView';
 
 function formatSourceLabel(source: 'api' | 'mock'): string {
   return source === 'api' ? 'Live API' : 'Mock data';
@@ -40,10 +31,9 @@ function getChatToggleLabel(isChatOpen: boolean): string {
 }
 
 export default function App() {
-  const { data, source, isLoading, error, refetch } = useGraphData();
+  const { data, source, error, refetch } = useGraphData();
   const [query, setQuery] = useState('');
   const deferredQuery = useDeferredValue(query);
-  const [hoveredNode, setHoveredNode] = useState<GraphNode | null>(null);
   const [view, setView] = useState<'graph' | 'editor'>('graph');
   const [isChatOpen, setIsChatOpen] = useState(true);
   const matchCount = findMatchingNodeIds(data.nodes, deferredQuery).size;
@@ -104,36 +94,6 @@ export default function App() {
             ) : null}
           </section>
 
-          <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-4">
-            <div className="flex items-center justify-between">
-              <h2 className="text-sm font-medium text-slate-200">Node legend</h2>
-              {isLoading ? (
-                <span className="text-xs uppercase tracking-[0.24em] text-cyan-200/70">
-                  Loading
-                </span>
-              ) : null}
-            </div>
-            <div className="mt-4 space-y-3">
-              {NODE_TYPES.map((type) => (
-                <div key={type} className="flex items-center gap-3 text-sm text-slate-300">
-                  <span
-                    className="h-3 w-3 rounded-full shadow-[0_0_18px_currentColor]"
-                    style={{ backgroundColor: NODE_TYPE_COLORS[type], color: NODE_TYPE_COLORS[type] }}
-                  />
-                  <span>{type}</span>
-                </div>
-              ))}
-            </div>
-          </section>
-
-          <section className="rounded-3xl border border-white/10 bg-slate-900/60 p-4 text-sm text-slate-300">
-            <h2 className="font-medium text-slate-200">Hover details</h2>
-            <p className="mt-3 leading-6">
-              {hoveredNode
-                ? `${hoveredNode.name} is active in the graph.`
-                : 'Hover a node to inspect its local neighborhood.'}
-            </p>
-          </section>
         </aside>
 
         <section className="min-h-[70vh] lg:min-h-0 lg:overflow-hidden">
@@ -151,8 +111,6 @@ export default function App() {
               data={data}
               source={source}
               query={deferredQuery}
-              hoveredNode={hoveredNode}
-              onHoverNode={setHoveredNode}
             />
           )}
         </section>

--- a/frontend/src/components/Graph3D.tsx
+++ b/frontend/src/components/Graph3D.tsx
@@ -95,8 +95,8 @@ interface Graph3DProps {
   data: GraphData;
   source: GraphSource;
   query: string;
-  hoveredNode: GraphNode | null;
-  onHoverNode: (node: GraphNode | null) => void;
+  hoveredNode?: GraphNode | null;
+  onHoverNode?: (node: GraphNode | null) => void;
 }
 
 interface SelectedRelationshipEdge {
@@ -154,9 +154,12 @@ export function Graph3D({
   data,
   source: graphSource,
   query,
-  hoveredNode,
-  onHoverNode,
+  hoveredNode: hoveredNodeProp,
+  onHoverNode: onHoverNodeProp,
 }: Graph3DProps) {
+  const [internalHoveredNode, setInternalHoveredNode] = useState<GraphNode | null>(null);
+  const hoveredNode = hoveredNodeProp ?? internalHoveredNode;
+  const onHoverNode = onHoverNodeProp ?? setInternalHoveredNode;
   const containerRef = useRef<HTMLDivElement | null>(null);
   const graphRef = useRef<ForceGraphHandle | null>(null);
   const brainContainmentRef = useRef<BrainContainment | null>(null);


### PR DESCRIPTION
## Summary
- Removed the "Node legend" section (5 colored dots with type labels) from the left sidebar
- Removed the "Hover details" section ("Hover a node to inspect...") from the left sidebar
- Graph3D now manages hover state internally — `hoveredNode`/`onHoverNode` props are optional
- Sidebar now contains: header, search, ingest panel, and data source summary only

## Test plan
- [ ] Sidebar renders without legend or hover details
- [ ] Node hover tooltip still works on the graph (managed internally by Graph3D)
- [ ] All 92 frontend tests pass

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)