### PR TITLE
Fix nodes detaching from brain and ghost lines in expanded view

### DIFF
--- a/frontend/src/components/Graph3D.tsx
+++ b/frontend/src/components/Graph3D.tsx
@@ -1192,7 +1192,8 @@ export function Graph3D({
 
       brainGroupRef.current = brainGroup;
       scene.add(brainGroup);
-      // Reheat the simulation so it re-runs with brain containment clamping active
+      // Reset settled flag so the reheated simulation runs clamping in onEngineTick
+      simulationSettledRef.current = false;
       (graphRef.current as any)?.d3ReheatSimulation?.();
       handleReset();
     });
@@ -1212,6 +1213,16 @@ export function Graph3D({
 
   useEffect(() => {
     clampNodesWithinBrain(true);
+    // Sync pin map with clamped positions
+    if (brainContainmentRef.current) {
+      const pins = pinnedPositionsRef.current;
+      displayData.nodes.forEach((n) => {
+        pins.set(n.id, { x: n.x ?? 0, y: n.y ?? 0, z: n.z ?? 0 });
+        n.fx = n.x;
+        n.fy = n.y;
+        n.fz = n.z;
+      });
+    }
   }, [displayData.nodes]);
 
   // Fade + hide brain wireframe during dive and when in expanded concept view
@@ -1529,6 +1540,16 @@ export function Graph3D({
   }
 
   function getLinkColor(link: GraphLink): string {
+    // When a concept is expanded, only show doc↔doc links; hide everything else
+    if (expandedNodeIds) {
+      const sourceId = typeof link.source === 'string' ? link.source : link.source.id;
+      const targetId = typeof link.target === 'string' ? link.target : link.target.id;
+      if (expandedNodeIds.has(sourceId) && expandedNodeIds.has(targetId)) {
+        return ACTIVE_LINK_COLOR;
+      }
+      return 'rgba(0,0,0,0)';
+    }
+
     if (isGhostLink(link)) {
       return GHOST_EDGE_COLOR;
     }
@@ -1541,16 +1562,6 @@ export function Graph3D({
         return DIMMED_LINK_COLOR;
       }
       return SEMANTIC_BRIDGE_COLOR;
-    }
-
-    // When a concept is expanded, only show doc↔doc links; hide everything else
-    if (expandedNodeIds) {
-      const sourceId = typeof link.source === 'string' ? link.source : link.source.id;
-      const targetId = typeof link.target === 'string' ? link.target : link.target.id;
-      if (expandedNodeIds.has(sourceId) && expandedNodeIds.has(targetId)) {
-        return ACTIVE_LINK_COLOR;
-      }
-      return 'rgba(0,0,0,0)';
     }
 
     if (isSelectedLink(link)) {
@@ -1569,6 +1580,14 @@ export function Graph3D({
   }
 
   function getLinkWidth(link: GraphLink): number {
+    if (expandedNodeIds) {
+      const sourceId = typeof link.source === 'string' ? link.source : link.source.id;
+      const targetId = typeof link.target === 'string' ? link.target : link.target.id;
+      if (!expandedNodeIds.has(sourceId) || !expandedNodeIds.has(targetId)) {
+        return 0;
+      }
+    }
+
     if (isGhostLink(link)) {
       return GHOST_EDGE_WIDTH;
     }


### PR DESCRIPTION
## Summary
- **Nodes detaching from brain**: `simulationSettledRef` was never reset after the brain model loaded and reheated the simulation. `onEngineTick` would re-pin nodes to pre-clamp positions, overriding containment. Now resets the flag before reheat, and the clamp effect syncs the pin map.
- **Ghost lines in expanded view**: `getLinkColor` and `getLinkWidth` checked for ghost/semantic bridge links before the `expandedNodeIds` guard, so those links rendered visibly in the expanded concept view. Moved the expanded check to the top of both functions.

## Test plan
- [x] 155 frontend tests pass
- [x] 230 backend tests pass
- [ ] Manual: all nodes stay inside the brain wireframe after load and after clicking
- [ ] Manual: expanded concept view shows only doc-to-doc links, no ghost/purple lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)